### PR TITLE
Reversion of #117 due to cmdstan 2.30.1 fixes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ## Package
 - Added `.Rhistory` to the `.gitignore` file. See #132 by @choi-hannah.
 - Fixed indentations for authors and contributors in the `DESCRIPTION` file. See #132 by @choi-hannah.
-- Reverts the changes made to `stanc_options` defaults in `enw_model()` as part of #117 in light of the new [`cmdstan 2.30.1` release](https://blog.mc-stan.org/2022/07/27/release-of-cmdstan-2-30-1/) which fixed upstream compilation bugs introduced by optimisation. This change means `epinowcast` again takes advantage of simple optimisations to speed up model fitting. More extreme optimisations are available but have not been tested. See the [`cmdstanr`](https://mc-stan.org/cmdstanr/) documentation for details. See # by @seabbs
+- Reverts the changes made to `stanc_options` defaults in `enw_model()` as part of #117 in light of the new [`cmdstan 2.30.1` release](https://blog.mc-stan.org/2022/07/27/release-of-cmdstan-2-30-1/) which fixed upstream compilation bugs introduced by optimisation. This change means `epinowcast` again takes advantage of simple optimisations to speed up model fitting. More extreme optimisations are available but have not been tested. See the [`cmdstanr`](https://mc-stan.org/cmdstanr/) documentation for details. See #146 by @seabbs
 
 ## Model
 - Added support for parametric log-logistic delay distributions. See #128 by @adrian-lison.

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Package
 - Added `.Rhistory` to the `.gitignore` file. See #132 by @choi-hannah.
 - Fixed indentations for authors and contributors in the `DESCRIPTION` file. See #132 by @choi-hannah.
+- Reverts the changes made to `stanc_options` defaults in `enw_model()` as part of #117 in light of the new [`cmdstan 2.30.1` release](https://blog.mc-stan.org/2022/07/27/release-of-cmdstan-2-30-1/) which fixed upstream compilation bugs introduced by optimisation. This change means `epinowcast` again takes advantage of simple optimisations to speed up model fitting. More extreme optimisations are available but have not been tested. See the [`cmdstanr`](https://mc-stan.org/cmdstanr/) documentation for details. See # by @seabbs
 
 ## Model
 - Added support for parametric log-logistic delay distributions. See #128 by @adrian-lison.

--- a/R/model-tools.R
+++ b/R/model-tools.R
@@ -275,8 +275,8 @@ enw_sample <- function(data, model = epinowcast::enw_model(),
 #' For more on profiling see the [`cmdstanr` documentation](https://mc-stan.org/cmdstanr/articles/profiling.html). # nolint
 #'
 #' @param stanc_options A list of options to pass to the `stanc_options` of
-#' [cmdstanr::cmdstan_model()]. By default nothing is passed but potentially
-#' users may wish to pass optimisation flags for example.See the documentation
+#' [cmdstanr::cmdstan_model()]. By default "O1" is passed which specifies simple
+#' optimisations should be done prior to compilation. See the documentation
 #' for [cmdstanr::cmdstan_model()] for further details.
 #'
 #' @param ... Additional arguments passed to [cmdstanr::cmdstan_model()].
@@ -290,7 +290,7 @@ enw_sample <- function(data, model = epinowcast::enw_model(),
 #' mod <- enw_model()
 enw_model <- function(model, include, compile = TRUE,
                       threads = FALSE, profile = FALSE,
-                      stanc_options = list(), verbose = TRUE, ...) {
+                      stanc_options = list("O1"), verbose = TRUE, ...) {
   if (missing(model)) {
     model <- "stan/epinowcast.stan"
     model <- system.file(model, package = "epinowcast")

--- a/man/enw_model.Rd
+++ b/man/enw_model.Rd
@@ -10,7 +10,7 @@ enw_model(
   compile = TRUE,
   threads = FALSE,
   profile = FALSE,
-  stanc_options = list(),
+  stanc_options = list("O1"),
   verbose = TRUE,
   ...
 )
@@ -34,8 +34,8 @@ and \code{\link[=epinowcast]{epinowcast()}}.}
 For more on profiling see the \href{https://mc-stan.org/cmdstanr/articles/profiling.html}{\code{cmdstanr} documentation}. # nolint}
 
 \item{stanc_options}{A list of options to pass to the \code{stanc_options} of
-\code{\link[cmdstanr:cmdstan_model]{cmdstanr::cmdstan_model()}}. By default nothing is passed but potentially
-users may wish to pass optimisation flags for example.See the documentation
+\code{\link[cmdstanr:cmdstan_model]{cmdstanr::cmdstan_model()}}. By default "O1" is passed which specifies simple
+optimisations should be done prior to compilation. See the documentation
 for \code{\link[cmdstanr:cmdstan_model]{cmdstanr::cmdstan_model()}} for further details.}
 
 \item{verbose}{Logical, defaults to \code{TRUE}. Should verbose


### PR DESCRIPTION
Reverts the changes made to `stanc_options` defaults in `enw_model()` as part of #117 in light of the new [`cmdstan 2.30.1` release](https://blog.mc-stan.org/2022/07/27/release-of-cmdstan-2-30-1/) which fixed upstream compilation bugs introduced by optimisation. This change means `epinowcast` again takes advantage of simple optimisations to speed up model fitting. More extreme optimisations are available but have not been tested.