### PR TITLE
Rewrite some formula_tools functions without regex

### DIFF
--- a/R/formula-tools.R
+++ b/R/formula-tools.R
@@ -158,19 +158,17 @@ rw_terms <- function(formula) {
 #'
 #' epinowcast:::remove_rw_terms(~ 1 + age_group + location + rw(week, location))
 remove_rw_terms <- function(formula) {
-  form <- as_string_formula(formula)
-  form <- gsub("rw\\(.*?\\) \\+ ", "", form)
-  form <- gsub("\\+ rw\\(.*?\\)", "", form)
-  form <- gsub("rw\\(.*?\\)", "", form)
 
-  form <- tryCatch(
-    {
-      as.formula(form)
-    },
-    error = function(cond) {
-      as.formula(paste(form, 1))
-    }
-  )
+  trms <- terms(formula, specials = "rw")
+
+  newtrms <- labels(drop.terms(trms, attr(trms, "specials")$rw))
+
+  if (attr(trms, "intercept") == 1) {
+    newtrms <- c(1, newtrms)
+  }
+
+  form <- reformulate(newtrms)
+
   return(form)
 }
 
@@ -625,3 +623,4 @@ enw_formula <- function(formula, data, sparse = TRUE) {
   class(out) <- c("enw_formula", class(out))
   return(out)
 }
+

--- a/R/formula-tools.R
+++ b/R/formula-tools.R
@@ -129,14 +129,14 @@ split_formula_to_terms <- function(formula) {
 #' epinowcast:::rw_terms(~ 1 + age_group + location)
 #'
 #' epinowcast:::rw_terms(~ 1 + age_group + location + rw(week, location))
+#'
+# FIXME: add an example & a test where rw() is in a random effect term. It
+# should then be ignored
 rw_terms <- function(formula) {
-  # use regex to find random walk terms in formula
-  trms <- attr(terms(formula), "term.labels")
-  match <- grepl("(^(rw)\\([^:]*\\))$", trms)
 
-  # ignore when included in a random effects term
-  match <- match & !grepl("\\|", trms)
-  return(trms[match])
+  trms <- terms(formula, specials = "rw")
+
+  return(labels(trms)[attr(trms, "specials")$rw])
 }
 
 #' Remove random walk terms from a formula object


### PR DESCRIPTION
Putting this here for discussion. Not sure if it's desirable or not.

Only change compared with current version is that `remove_rw_terms()` is now associated with an environment. It can probably be changed but I'm not completely sure why formulas are usually linked to environments so I didn't touch it.