### PR TITLE
Feature: interactions in random effects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@ a series of dates. Changed interface of `enw_preprocess_data()` to pass `...` to
 - Skipped tests that use `cmdstan` locally to improve the developer/contributor experience. See #147 by @seabbs and @adrian-lison.
 - Added a basic simulator function for missing reference data. See #147 by @seabbs and @adrian-lison.
 - Added a basic simulator function for missing reference data. See #147 by @seabbs and @adrian-lison.
+- Added support for right hand side interactions as syntax sugar for random effects. This allows the specification of, for example, independent random effects by day for each strata of another variable. See #169 by @seabbs.
 
 ## Model
 - Added support for parametric log-logistic delay distributions. See #128 by @adrian-lison.

--- a/R/formula-tools.R
+++ b/R/formula-tools.R
@@ -397,6 +397,7 @@ re <- function(formula) {
 #'
 #' @family formulatools
 #' @importFrom data.table as.data.table
+#' @importFrom purrr map
 #' @examples
 #' # Simple examples
 #' form <- epinowcast:::parse_formula(~ 1 + (1 | day_of_week))
@@ -423,16 +424,22 @@ construct_re <- function(re, data) {
   fixed <- strsplit(re$fixed, " \\+ ")[[1]]
   random <- strsplit(re$random, " \\+ ")[[1]]
 
-  for (i in random) {
-    current_random <- strsplit(i, ":")[[1]]
+  # expand random effects that are interactions
+  expanded_random <- c()
+  random_int <- rep(FALSE, length(random))
+  for (i in seq_along(random)) {
+    current_random <- strsplit(random[i], ":")[[1]]
+    expanded_random <- c(expanded_random, current_random)
     if (length(current_random) > 1) {
       if (length(current_random) > 2) {
         stop(
           "Interactions between more than 2 variables are not currently supported on the right hand side of random effects" # nolint
         )
       }
+      random_int[i] <- TRUE
     }
   }
+  expanded_random <- unique(expanded_random)
   # detect if random effect interactions are present
   # loop through random effect interactions
   # make new random effects using unique values
@@ -448,7 +455,9 @@ construct_re <- function(re, data) {
   terms <- terms[!startsWith(terms, "0:")]
 
   # make all right hand side random effects factors
-  data <- data[, (random) := lapply(.SD, as.factor), .SDcols = random]
+  data <- data[,
+    (expanded_random) := lapply(.SD, as.factor), .SDcols = expanded_random
+  ]
 
   # make a fixed effects design matrix
   fixed <- enw_manual_formula(
@@ -461,22 +470,62 @@ construct_re <- function(re, data) {
   effects <- enw_effects_metadata(fixed)
 
   # implement random effects structure
-  for (i in terms) {
+  for (i in seq_along(terms)) {
     loc_terms <- strsplit(i, ":")[[1]]
-    if (length(loc_terms) == 1) {
-      effects <- enw_add_pooling_effect(
-        effects, i, i,
-        finder_fn = function(effect, pattern) {
-          grepl(pattern, effect) & !grepl(":", effect)
+    # expand right hand side random effect if its an interaction
+    # and make a list to map to effects
+    if (random_int[i]) {
+      expanded_int <- unique(data[[loc_terms[length(loc_terms)]]])
+      expanded_int <- paste0(loc_terms[length(loc_terms)], expanded_int)
+      j <- purrr::map(expanded_int, function(x) {
+        j <- c()
+        if (length(loc_terms) > 2) {
+          j <- loc_terms[1:(length(loc_terms) - 2)]
         }
-      )
-    } else {
-      effects <- enw_add_pooling_effect(
-        effects, rev(loc_terms), paste(loc_terms, collapse = "__"),
-        finder_fn = function(effect, pattern) {
-          grepl(pattern[1], effect) & grepl(pattern[2], effect)
+        j <- c(j, paste0(loc_terms[length(loc_terms) - 1], ":", x))
+        return(j)
+      })
+    }else {
+      j <- list(loc_terms)
+    }
+    for (k in j) {
+      if (length(k) == 1) {
+          if (random_int[i]) {
+            effects <- enw_add_pooling_effect(
+              effects, strsplit(k, ":")[[1]], gsub(":", "__", k),
+              finder_fn = function(effect, pattern) {
+                grepl(pattern[1], effect) &
+                grepl(pattern[2], effect, fixed = TRUE) &
+                lengths(regmatches(effect, gregexpr(":", effect))) == 1
+              }
+            )
+          }else {
+            effects <- enw_add_pooling_effect(
+              effects, k, k,
+              finder_fn = function(effect, pattern) {
+                grepl(pattern, effect) & !grepl(":", effect)
+              }
+            )
+          }
+      } else {
+        if (random_int[i]) {
+          effects <- enw_add_pooling_effect(
+              effects, c(k[1], strsplit(k[-1], ":")[[1]]),
+              paste(gsub(":", "__", k, collapse = "__")),
+              finder_fn = function(effect, pattern) {
+                grepl(pattern[1], effect) & grepl(pattern[2], effect) & 
+                grepl(pattern[3], effect)
+            }
+          )
+        }else {
+          effects <- enw_add_pooling_effect(
+            effects, rev(k), paste(k, collapse = "__"),
+            finder_fn = function(effect, pattern) {
+              grepl(pattern[1], effect) & grepl(pattern[2], effect)
+            }
+          )
         }
-      )
+      }
     }
   }
   return(list(data = data, terms = terms, effects = effects))

--- a/R/formula-tools.R
+++ b/R/formula-tools.R
@@ -593,6 +593,10 @@ construct_re <- function(re, data) {
 #'
 #' # Model defined without a sparse fixed effects design matrix
 #' enw_formula(~1, data[1:20, ])
+#'
+#' # Model using an interaction in the right hand side of a random effect
+#' # to specify an independent random effect per strata.
+#' enw_formula(~ (1 + day | week:month), data = data)
 enw_formula <- function(formula, data, sparse = TRUE) {
   data <- data.table::as.data.table(data)
 

--- a/R/formula-tools.R
+++ b/R/formula-tools.R
@@ -423,6 +423,12 @@ construct_re <- function(re, data) {
   fixed <- strsplit(re$fixed, " \\+ ")[[1]]
   random <- strsplit(re$random, " \\+ ")[[1]]
 
+  # detect if random effect interactions are present
+  # loop through random effect interactions
+  # make new random effects using unique values
+  # add these new random effects to the data
+  # add these new random effects to list of all random effects
+  
   # combine into fixed effects terms
   terms <- c()
   for (i in random) {

--- a/R/formula-tools.R
+++ b/R/formula-tools.R
@@ -423,12 +423,22 @@ construct_re <- function(re, data) {
   fixed <- strsplit(re$fixed, " \\+ ")[[1]]
   random <- strsplit(re$random, " \\+ ")[[1]]
 
+  for (i in random) {
+    current_random <- strsplit(i, ":")[[1]]
+    if (length(current_random) > 1) {
+      if (length(current_random) > 2) {
+        stop(
+          "Interactions between more than 2 variables are not currently supported on the right hand side of random effects" # nolint
+        )
+      }
+    }
+  }
   # detect if random effect interactions are present
   # loop through random effect interactions
   # make new random effects using unique values
   # add these new random effects to the data
   # add these new random effects to list of all random effects
-  
+
   # combine into fixed effects terms
   terms <- c()
   for (i in random) {

--- a/man/enw_formula.Rd
+++ b/man/enw_formula.Rd
@@ -60,6 +60,10 @@ enw_formula(~ 1 + (1 | age_group) + rw(week), data)
 
 # Model defined without a sparse fixed effects design matrix
 enw_formula(~1, data[1:20, ])
+
+# Model using an interaction in the right hand side of a random effect
+# to specify an independent random effect per strata.
+enw_formula(~ (1 + day | week:month), data = data)
 }
 \seealso{
 Functions used to help convert formulas into model designs

--- a/tests/testthat/_snaps/enw_formula.md
+++ b/tests/testthat/_snaps/enw_formula.md
@@ -109,6 +109,912 @@
       attr(,"class")
       [1] "enw_formula" "list"       
 
+# enw_formula can return a random effects formula with an internal
+           interaction
+
+    Code
+      enw_formula(~ 1 + (1 + month | day_of_week:age_group), data)
+    Output
+      $formula
+      [1] "~1 + (1 + month | day_of_week:age_group)"
+      
+      $parsed_formula
+      $parsed_formula$fixed
+      [1] "1"
+      
+      $parsed_formula$random
+      $parsed_formula$random[[1]]
+      1 + month | day_of_week:age_group
+      
+      
+      $parsed_formula$rw
+      character(0)
+      
+      
+      $expanded_formula
+      [1] "~1 + day_of_week:age_group + month:day_of_week:age_group"
+      
+      $fixed
+      $fixed$formula
+      [1] "~1 + day_of_week:age_group + month:day_of_week:age_group"
+      
+      $fixed$design
+         (Intercept) day_of_weekFriday:age_group00+ day_of_weekMonday:age_group00+
+      1            1                              0                              0
+      2            1                              1                              0
+      3            1                              0                              0
+      4            1                              0                              0
+      5            1                              0                              1
+      6            1                              0                              0
+      7            1                              0                              0
+      8            1                              0                              0
+      12           1                              0                              0
+      13           1                              0                              0
+      14           1                              0                              0
+      15           1                              0                              0
+      16           1                              0                              0
+      17           1                              0                              0
+      18           1                              0                              0
+      19           1                              0                              0
+      23           1                              0                              0
+      24           1                              0                              0
+      25           1                              0                              0
+      26           1                              0                              0
+      27           1                              0                              0
+      28           1                              0                              0
+      29           1                              0                              0
+      30           1                              0                              0
+         day_of_weekSaturday:age_group00+ day_of_weekSunday:age_group00+
+      1                                 0                              0
+      2                                 0                              0
+      3                                 1                              0
+      4                                 0                              1
+      5                                 0                              0
+      6                                 0                              0
+      7                                 0                              0
+      8                                 0                              0
+      12                                0                              0
+      13                                0                              0
+      14                                0                              0
+      15                                0                              0
+      16                                0                              0
+      17                                0                              0
+      18                                0                              0
+      19                                0                              0
+      23                                0                              0
+      24                                0                              0
+      25                                0                              0
+      26                                0                              0
+      27                                0                              0
+      28                                0                              0
+      29                                0                              0
+      30                                0                              0
+         day_of_weekThursday:age_group00+ day_of_weekTuesday:age_group00+
+      1                                 1                               0
+      2                                 0                               0
+      3                                 0                               0
+      4                                 0                               0
+      5                                 0                               0
+      6                                 0                               1
+      7                                 0                               0
+      8                                 1                               0
+      12                                0                               0
+      13                                0                               0
+      14                                0                               0
+      15                                0                               0
+      16                                0                               0
+      17                                0                               0
+      18                                0                               0
+      19                                0                               0
+      23                                0                               0
+      24                                0                               0
+      25                                0                               0
+      26                                0                               0
+      27                                0                               0
+      28                                0                               0
+      29                                0                               0
+      30                                0                               0
+         day_of_weekWednesday:age_group00+ day_of_weekFriday:age_group05-14
+      1                                  0                                0
+      2                                  0                                0
+      3                                  0                                0
+      4                                  0                                0
+      5                                  0                                0
+      6                                  0                                0
+      7                                  1                                0
+      8                                  0                                0
+      12                                 0                                0
+      13                                 0                                1
+      14                                 0                                0
+      15                                 0                                0
+      16                                 0                                0
+      17                                 0                                0
+      18                                 0                                0
+      19                                 0                                0
+      23                                 0                                0
+      24                                 0                                0
+      25                                 0                                0
+      26                                 0                                0
+      27                                 0                                0
+      28                                 0                                0
+      29                                 0                                0
+      30                                 0                                0
+         day_of_weekMonday:age_group05-14 day_of_weekSaturday:age_group05-14
+      1                                 0                                  0
+      2                                 0                                  0
+      3                                 0                                  0
+      4                                 0                                  0
+      5                                 0                                  0
+      6                                 0                                  0
+      7                                 0                                  0
+      8                                 0                                  0
+      12                                0                                  0
+      13                                0                                  0
+      14                                0                                  1
+      15                                0                                  0
+      16                                1                                  0
+      17                                0                                  0
+      18                                0                                  0
+      19                                0                                  0
+      23                                0                                  0
+      24                                0                                  0
+      25                                0                                  0
+      26                                0                                  0
+      27                                0                                  0
+      28                                0                                  0
+      29                                0                                  0
+      30                                0                                  0
+         day_of_weekSunday:age_group05-14 day_of_weekThursday:age_group05-14
+      1                                 0                                  0
+      2                                 0                                  0
+      3                                 0                                  0
+      4                                 0                                  0
+      5                                 0                                  0
+      6                                 0                                  0
+      7                                 0                                  0
+      8                                 0                                  0
+      12                                0                                  1
+      13                                0                                  0
+      14                                0                                  0
+      15                                1                                  0
+      16                                0                                  0
+      17                                0                                  0
+      18                                0                                  0
+      19                                0                                  1
+      23                                0                                  0
+      24                                0                                  0
+      25                                0                                  0
+      26                                0                                  0
+      27                                0                                  0
+      28                                0                                  0
+      29                                0                                  0
+      30                                0                                  0
+         day_of_weekTuesday:age_group05-14 day_of_weekWednesday:age_group05-14
+      1                                  0                                   0
+      2                                  0                                   0
+      3                                  0                                   0
+      4                                  0                                   0
+      5                                  0                                   0
+      6                                  0                                   0
+      7                                  0                                   0
+      8                                  0                                   0
+      12                                 0                                   0
+      13                                 0                                   0
+      14                                 0                                   0
+      15                                 0                                   0
+      16                                 0                                   0
+      17                                 1                                   0
+      18                                 0                                   1
+      19                                 0                                   0
+      23                                 0                                   0
+      24                                 0                                   0
+      25                                 0                                   0
+      26                                 0                                   0
+      27                                 0                                   0
+      28                                 0                                   0
+      29                                 0                                   0
+      30                                 0                                   0
+         day_of_weekFriday:age_group15-34 day_of_weekMonday:age_group15-34
+      1                                 0                                0
+      2                                 0                                0
+      3                                 0                                0
+      4                                 0                                0
+      5                                 0                                0
+      6                                 0                                0
+      7                                 0                                0
+      8                                 0                                0
+      12                                0                                0
+      13                                0                                0
+      14                                0                                0
+      15                                0                                0
+      16                                0                                0
+      17                                0                                0
+      18                                0                                0
+      19                                0                                0
+      23                                0                                0
+      24                                1                                0
+      25                                0                                0
+      26                                0                                0
+      27                                0                                1
+      28                                0                                0
+      29                                0                                0
+      30                                0                                0
+         day_of_weekSaturday:age_group15-34 day_of_weekSunday:age_group15-34
+      1                                   0                                0
+      2                                   0                                0
+      3                                   0                                0
+      4                                   0                                0
+      5                                   0                                0
+      6                                   0                                0
+      7                                   0                                0
+      8                                   0                                0
+      12                                  0                                0
+      13                                  0                                0
+      14                                  0                                0
+      15                                  0                                0
+      16                                  0                                0
+      17                                  0                                0
+      18                                  0                                0
+      19                                  0                                0
+      23                                  0                                0
+      24                                  0                                0
+      25                                  1                                0
+      26                                  0                                1
+      27                                  0                                0
+      28                                  0                                0
+      29                                  0                                0
+      30                                  0                                0
+         day_of_weekThursday:age_group15-34 day_of_weekTuesday:age_group15-34
+      1                                   0                                 0
+      2                                   0                                 0
+      3                                   0                                 0
+      4                                   0                                 0
+      5                                   0                                 0
+      6                                   0                                 0
+      7                                   0                                 0
+      8                                   0                                 0
+      12                                  0                                 0
+      13                                  0                                 0
+      14                                  0                                 0
+      15                                  0                                 0
+      16                                  0                                 0
+      17                                  0                                 0
+      18                                  0                                 0
+      19                                  0                                 0
+      23                                  1                                 0
+      24                                  0                                 0
+      25                                  0                                 0
+      26                                  0                                 0
+      27                                  0                                 0
+      28                                  0                                 1
+      29                                  0                                 0
+      30                                  1                                 0
+         day_of_weekWednesday:age_group15-34 day_of_weekFriday:age_group00+:month
+      1                                    0                                    0
+      2                                    0                                    1
+      3                                    0                                    0
+      4                                    0                                    0
+      5                                    0                                    0
+      6                                    0                                    0
+      7                                    0                                    0
+      8                                    0                                    0
+      12                                   0                                    0
+      13                                   0                                    0
+      14                                   0                                    0
+      15                                   0                                    0
+      16                                   0                                    0
+      17                                   0                                    0
+      18                                   0                                    0
+      19                                   0                                    0
+      23                                   0                                    0
+      24                                   0                                    0
+      25                                   0                                    0
+      26                                   0                                    0
+      27                                   0                                    0
+      28                                   0                                    0
+      29                                   1                                    0
+      30                                   0                                    0
+         day_of_weekMonday:age_group00+:month day_of_weekSaturday:age_group00+:month
+      1                                     0                                      0
+      2                                     0                                      0
+      3                                     0                                      1
+      4                                     0                                      0
+      5                                     1                                      0
+      6                                     0                                      0
+      7                                     0                                      0
+      8                                     0                                      0
+      12                                    0                                      0
+      13                                    0                                      0
+      14                                    0                                      0
+      15                                    0                                      0
+      16                                    0                                      0
+      17                                    0                                      0
+      18                                    0                                      0
+      19                                    0                                      0
+      23                                    0                                      0
+      24                                    0                                      0
+      25                                    0                                      0
+      26                                    0                                      0
+      27                                    0                                      0
+      28                                    0                                      0
+      29                                    0                                      0
+      30                                    0                                      0
+         day_of_weekSunday:age_group00+:month day_of_weekThursday:age_group00+:month
+      1                                     0                                      0
+      2                                     0                                      0
+      3                                     0                                      0
+      4                                     1                                      0
+      5                                     0                                      0
+      6                                     0                                      0
+      7                                     0                                      0
+      8                                     0                                      1
+      12                                    0                                      0
+      13                                    0                                      0
+      14                                    0                                      0
+      15                                    0                                      0
+      16                                    0                                      0
+      17                                    0                                      0
+      18                                    0                                      0
+      19                                    0                                      0
+      23                                    0                                      0
+      24                                    0                                      0
+      25                                    0                                      0
+      26                                    0                                      0
+      27                                    0                                      0
+      28                                    0                                      0
+      29                                    0                                      0
+      30                                    0                                      0
+         day_of_weekTuesday:age_group00+:month
+      1                                      0
+      2                                      0
+      3                                      0
+      4                                      0
+      5                                      0
+      6                                      1
+      7                                      0
+      8                                      0
+      12                                     0
+      13                                     0
+      14                                     0
+      15                                     0
+      16                                     0
+      17                                     0
+      18                                     0
+      19                                     0
+      23                                     0
+      24                                     0
+      25                                     0
+      26                                     0
+      27                                     0
+      28                                     0
+      29                                     0
+      30                                     0
+         day_of_weekWednesday:age_group00+:month
+      1                                        0
+      2                                        0
+      3                                        0
+      4                                        0
+      5                                        0
+      6                                        0
+      7                                        1
+      8                                        0
+      12                                       0
+      13                                       0
+      14                                       0
+      15                                       0
+      16                                       0
+      17                                       0
+      18                                       0
+      19                                       0
+      23                                       0
+      24                                       0
+      25                                       0
+      26                                       0
+      27                                       0
+      28                                       0
+      29                                       0
+      30                                       0
+         day_of_weekFriday:age_group05-14:month
+      1                                       0
+      2                                       0
+      3                                       0
+      4                                       0
+      5                                       0
+      6                                       0
+      7                                       0
+      8                                       0
+      12                                      0
+      13                                      1
+      14                                      0
+      15                                      0
+      16                                      0
+      17                                      0
+      18                                      0
+      19                                      0
+      23                                      0
+      24                                      0
+      25                                      0
+      26                                      0
+      27                                      0
+      28                                      0
+      29                                      0
+      30                                      0
+         day_of_weekMonday:age_group05-14:month
+      1                                       0
+      2                                       0
+      3                                       0
+      4                                       0
+      5                                       0
+      6                                       0
+      7                                       0
+      8                                       0
+      12                                      0
+      13                                      0
+      14                                      0
+      15                                      0
+      16                                      1
+      17                                      0
+      18                                      0
+      19                                      0
+      23                                      0
+      24                                      0
+      25                                      0
+      26                                      0
+      27                                      0
+      28                                      0
+      29                                      0
+      30                                      0
+         day_of_weekSaturday:age_group05-14:month
+      1                                         0
+      2                                         0
+      3                                         0
+      4                                         0
+      5                                         0
+      6                                         0
+      7                                         0
+      8                                         0
+      12                                        0
+      13                                        0
+      14                                        1
+      15                                        0
+      16                                        0
+      17                                        0
+      18                                        0
+      19                                        0
+      23                                        0
+      24                                        0
+      25                                        0
+      26                                        0
+      27                                        0
+      28                                        0
+      29                                        0
+      30                                        0
+         day_of_weekSunday:age_group05-14:month
+      1                                       0
+      2                                       0
+      3                                       0
+      4                                       0
+      5                                       0
+      6                                       0
+      7                                       0
+      8                                       0
+      12                                      0
+      13                                      0
+      14                                      0
+      15                                      1
+      16                                      0
+      17                                      0
+      18                                      0
+      19                                      0
+      23                                      0
+      24                                      0
+      25                                      0
+      26                                      0
+      27                                      0
+      28                                      0
+      29                                      0
+      30                                      0
+         day_of_weekThursday:age_group05-14:month
+      1                                         0
+      2                                         0
+      3                                         0
+      4                                         0
+      5                                         0
+      6                                         0
+      7                                         0
+      8                                         0
+      12                                        0
+      13                                        0
+      14                                        0
+      15                                        0
+      16                                        0
+      17                                        0
+      18                                        0
+      19                                        1
+      23                                        0
+      24                                        0
+      25                                        0
+      26                                        0
+      27                                        0
+      28                                        0
+      29                                        0
+      30                                        0
+         day_of_weekTuesday:age_group05-14:month
+      1                                        0
+      2                                        0
+      3                                        0
+      4                                        0
+      5                                        0
+      6                                        0
+      7                                        0
+      8                                        0
+      12                                       0
+      13                                       0
+      14                                       0
+      15                                       0
+      16                                       0
+      17                                       1
+      18                                       0
+      19                                       0
+      23                                       0
+      24                                       0
+      25                                       0
+      26                                       0
+      27                                       0
+      28                                       0
+      29                                       0
+      30                                       0
+         day_of_weekWednesday:age_group05-14:month
+      1                                          0
+      2                                          0
+      3                                          0
+      4                                          0
+      5                                          0
+      6                                          0
+      7                                          0
+      8                                          0
+      12                                         0
+      13                                         0
+      14                                         0
+      15                                         0
+      16                                         0
+      17                                         0
+      18                                         1
+      19                                         0
+      23                                         0
+      24                                         0
+      25                                         0
+      26                                         0
+      27                                         0
+      28                                         0
+      29                                         0
+      30                                         0
+         day_of_weekFriday:age_group15-34:month
+      1                                       0
+      2                                       0
+      3                                       0
+      4                                       0
+      5                                       0
+      6                                       0
+      7                                       0
+      8                                       0
+      12                                      0
+      13                                      0
+      14                                      0
+      15                                      0
+      16                                      0
+      17                                      0
+      18                                      0
+      19                                      0
+      23                                      0
+      24                                      1
+      25                                      0
+      26                                      0
+      27                                      0
+      28                                      0
+      29                                      0
+      30                                      0
+         day_of_weekMonday:age_group15-34:month
+      1                                       0
+      2                                       0
+      3                                       0
+      4                                       0
+      5                                       0
+      6                                       0
+      7                                       0
+      8                                       0
+      12                                      0
+      13                                      0
+      14                                      0
+      15                                      0
+      16                                      0
+      17                                      0
+      18                                      0
+      19                                      0
+      23                                      0
+      24                                      0
+      25                                      0
+      26                                      0
+      27                                      1
+      28                                      0
+      29                                      0
+      30                                      0
+         day_of_weekSaturday:age_group15-34:month
+      1                                         0
+      2                                         0
+      3                                         0
+      4                                         0
+      5                                         0
+      6                                         0
+      7                                         0
+      8                                         0
+      12                                        0
+      13                                        0
+      14                                        0
+      15                                        0
+      16                                        0
+      17                                        0
+      18                                        0
+      19                                        0
+      23                                        0
+      24                                        0
+      25                                        1
+      26                                        0
+      27                                        0
+      28                                        0
+      29                                        0
+      30                                        0
+         day_of_weekSunday:age_group15-34:month
+      1                                       0
+      2                                       0
+      3                                       0
+      4                                       0
+      5                                       0
+      6                                       0
+      7                                       0
+      8                                       0
+      12                                      0
+      13                                      0
+      14                                      0
+      15                                      0
+      16                                      0
+      17                                      0
+      18                                      0
+      19                                      0
+      23                                      0
+      24                                      0
+      25                                      0
+      26                                      1
+      27                                      0
+      28                                      0
+      29                                      0
+      30                                      0
+         day_of_weekThursday:age_group15-34:month
+      1                                         0
+      2                                         0
+      3                                         0
+      4                                         0
+      5                                         0
+      6                                         0
+      7                                         0
+      8                                         0
+      12                                        0
+      13                                        0
+      14                                        0
+      15                                        0
+      16                                        0
+      17                                        0
+      18                                        0
+      19                                        0
+      23                                        0
+      24                                        0
+      25                                        0
+      26                                        0
+      27                                        0
+      28                                        0
+      29                                        0
+      30                                        1
+         day_of_weekTuesday:age_group15-34:month
+      1                                        0
+      2                                        0
+      3                                        0
+      4                                        0
+      5                                        0
+      6                                        0
+      7                                        0
+      8                                        0
+      12                                       0
+      13                                       0
+      14                                       0
+      15                                       0
+      16                                       0
+      17                                       0
+      18                                       0
+      19                                       0
+      23                                       0
+      24                                       0
+      25                                       0
+      26                                       0
+      27                                       0
+      28                                       1
+      29                                       0
+      30                                       0
+         day_of_weekWednesday:age_group15-34:month
+      1                                          0
+      2                                          0
+      3                                          0
+      4                                          0
+      5                                          0
+      6                                          0
+      7                                          0
+      8                                          0
+      12                                         0
+      13                                         0
+      14                                         0
+      15                                         0
+      16                                         0
+      17                                         0
+      18                                         0
+      19                                         0
+      23                                         0
+      24                                         0
+      25                                         0
+      26                                         0
+      27                                         0
+      28                                         0
+      29                                         1
+      30                                         0
+      
+      $fixed$index
+       [1]  1  2  3  4  5  6  7  8  2  3  4  9 10 11 12 13 14 15 16 10 11 12 17 18 19
+      [26] 20 21 22 23 24 18 19 20
+      
+      
+      $random
+      $random$formula
+      [1] "~0 + fixed + `day_of_week__age_group00+` + `day_of_week__age_group05-14` + `day_of_week__age_group15-34` + `month__day_of_week__age_group00+` + `month__day_of_week__age_group05-14` + `month__day_of_week__age_group15-34`"
+      
+      $random$design
+         fixed `day_of_week__age_group00+` `day_of_week__age_group05-14`
+      1      0                           1                             0
+      2      0                           1                             0
+      3      0                           1                             0
+      4      0                           1                             0
+      5      0                           1                             0
+      6      0                           1                             0
+      7      0                           1                             0
+      8      0                           0                             1
+      9      0                           0                             1
+      10     0                           0                             1
+      11     0                           0                             1
+      12     0                           0                             1
+      13     0                           0                             1
+      14     0                           0                             1
+      15     0                           0                             0
+      16     0                           0                             0
+      17     0                           0                             0
+      18     0                           0                             0
+      19     0                           0                             0
+      20     0                           0                             0
+      21     0                           0                             0
+      22     0                           0                             0
+      23     0                           0                             0
+      24     0                           0                             0
+      25     0                           0                             0
+      26     0                           0                             0
+      27     0                           0                             0
+      28     0                           0                             0
+      29     0                           0                             0
+      30     0                           0                             0
+      31     0                           0                             0
+      32     0                           0                             0
+      33     0                           0                             0
+      34     0                           0                             0
+      35     0                           0                             0
+      36     0                           0                             0
+      37     0                           0                             0
+      38     0                           0                             0
+      39     0                           0                             0
+      40     0                           0                             0
+      41     0                           0                             0
+      42     0                           0                             0
+         `day_of_week__age_group15-34` `month__day_of_week__age_group00+`
+      1                              0                                  0
+      2                              0                                  0
+      3                              0                                  0
+      4                              0                                  0
+      5                              0                                  0
+      6                              0                                  0
+      7                              0                                  0
+      8                              0                                  0
+      9                              0                                  0
+      10                             0                                  0
+      11                             0                                  0
+      12                             0                                  0
+      13                             0                                  0
+      14                             0                                  0
+      15                             1                                  0
+      16                             1                                  0
+      17                             1                                  0
+      18                             1                                  0
+      19                             1                                  0
+      20                             1                                  0
+      21                             1                                  0
+      22                             0                                  1
+      23                             0                                  1
+      24                             0                                  1
+      25                             0                                  1
+      26                             0                                  1
+      27                             0                                  1
+      28                             0                                  1
+      29                             0                                  0
+      30                             0                                  0
+      31                             0                                  0
+      32                             0                                  0
+      33                             0                                  0
+      34                             0                                  0
+      35                             0                                  0
+      36                             0                                  0
+      37                             0                                  0
+      38                             0                                  0
+      39                             0                                  0
+      40                             0                                  0
+      41                             0                                  0
+      42                             0                                  0
+         `month__day_of_week__age_group05-14` `month__day_of_week__age_group15-34`
+      1                                     0                                    0
+      2                                     0                                    0
+      3                                     0                                    0
+      4                                     0                                    0
+      5                                     0                                    0
+      6                                     0                                    0
+      7                                     0                                    0
+      8                                     0                                    0
+      9                                     0                                    0
+      10                                    0                                    0
+      11                                    0                                    0
+      12                                    0                                    0
+      13                                    0                                    0
+      14                                    0                                    0
+      15                                    0                                    0
+      16                                    0                                    0
+      17                                    0                                    0
+      18                                    0                                    0
+      19                                    0                                    0
+      20                                    0                                    0
+      21                                    0                                    0
+      22                                    0                                    0
+      23                                    0                                    0
+      24                                    0                                    0
+      25                                    0                                    0
+      26                                    0                                    0
+      27                                    0                                    0
+      28                                    0                                    0
+      29                                    1                                    0
+      30                                    1                                    0
+      31                                    1                                    0
+      32                                    1                                    0
+      33                                    1                                    0
+      34                                    1                                    0
+      35                                    1                                    0
+      36                                    0                                    1
+      37                                    0                                    1
+      38                                    0                                    1
+      39                                    0                                    1
+      40                                    0                                    1
+      41                                    0                                    1
+      42                                    0                                    1
+      attr(,"assign")
+      [1] 1 2 3 4 5 6 7
+      
+      $random$index
+       [1]  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25
+      [26] 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42
+      
+      
+      attr(,"class")
+      [1] "enw_formula" "list"       
+
 # enw_formula can return a model with a random effect and a random
            walk
 

--- a/tests/testthat/test-enw_formula.R
+++ b/tests/testthat/test-enw_formula.R
@@ -20,7 +20,7 @@ test_that("enw_formula can return a basic random effects formula", {
 
 test_that("enw_formula can return a random effects formula with an internal
            interaction", {
-  expect_snapshot(enw_formula(~ 1 + (1 | age_group:day_of_week), data))
+  expect_snapshot(enw_formula(~ 1 + (1 + month | day_of_week:age_group), data))
 })
 
 test_that("enw_formula can return a model with a random effect and a random

--- a/tests/testthat/test-enw_formula.R
+++ b/tests/testthat/test-enw_formula.R
@@ -23,6 +23,14 @@ test_that("enw_formula can return a random effects formula with an internal
   expect_snapshot(enw_formula(~ 1 + (1 + month | day_of_week:age_group), data))
 })
 
+
+test_that("enw_formula cannot return a random effects formula with multiple
+           internal interaction", {
+  expect_error(
+    enw_formula(~ 1 + (1 + month | day_of_week:age_group:location), data)
+  )
+})
+
 test_that("enw_formula can return a model with a random effect and a random
            walk", {
   expect_snapshot(enw_formula(~ 1 + (1 | age_group) + rw(week), data))


### PR DESCRIPTION
This PR adds support for interactions on the right-hand side of random effects (i.e `(1 + month | day_of_week:age_group)`. This should result in a model with an independent random effect for each age group on the day of the week and random slopes on the month drawn from separate hyper distributions for each age group.

This feature is motivated by #152 where we need to be able to specify independent random effects for each group easily in order to reproduce the current default model. There may also be other use cases in the future. 

Potentially this syntax is not ideal and/or there are other work around to this feature that I am not aware of. 

I have added: 

- Functionality to support random effect interactions
- An example in the documentation of `enw_formula` showcasing this functionality
- A test for `enw_formula` that produces a snapshot. I have confirmed this snapshot has the desired design matrix structure. 
- A test checking that multiple interactions fail with a meaningful error (needed as this is more complex to implement and so is not yet in place).
- A news item highlighting this change.

I have also checked that none of the other functionality has been impacted by reviewing our other tests.

To test out the new functionality see below: 

```r
obs <- enw_filter_report_dates(
  germany_covid19_hosp[location == "DE"][
    age_group %in% c("00+", "05-14", "15-34")
  ],
  remove_days = 10
)
obs <- enw_filter_reference_dates(obs, include_days = 10)
pobs <- enw_preprocess_data(obs, by = c("age_group", "location"))
data <- pobs$metareference[[1]]

enw_formula(~ 1 + (1 + month | day_of_week:age_group), data)
```