### PR TITLE
Feature cpp options

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@ a series of dates. Changed interface of `enw_preprocess_data()` to pass `...` to
 - Skipped tests that use `cmdstan` locally to improve the developer/contributor experience. See #147 by @seabbs and @adrian-lison.
 - Added a basic simulator function for missing reference data. See #147 by @seabbs and @adrian-lison.
 - Added support for right hand side interactions as syntax sugar for random effects. This allows the specification of, for example, independent random effects by day for each strata of another variable. See #169 by @seabbs.
+- Added support for passing `cpp_options` to `cmdstanr::cmdstan_model()`. See #182 by @seabbs.
 
 ## Model
 - Added support for parametric log-logistic delay distributions. See #128 by @adrian-lison.

--- a/R/model-tools.R
+++ b/R/model-tools.R
@@ -307,7 +307,7 @@ enw_sample <- function(data, model = epinowcast::enw_model(),
 #' users may wish to pass optimisation flags for example. See the documentation
 #' for [cmdstanr::cmdstan_model()] for further details. Note that the `threads`
 #' argument replaces `stan_threads`.
-#' 
+#'
 #' @param ... Additional arguments passed to [cmdstanr::cmdstan_model()].
 #'
 #' @return A `cmdstanr` model.

--- a/R/model-tools.R
+++ b/R/model-tools.R
@@ -299,9 +299,15 @@ enw_sample <- function(data, model = epinowcast::enw_model(),
 #'
 #' @param stanc_options A list of options to pass to the `stanc_options` of
 #' [cmdstanr::cmdstan_model()]. By default nothing is passed but potentially
-#' users may wish to pass optimisation flags for example.See the documentation
+#' users may wish to pass optimisation flags for example. See the documentation
 #' for [cmdstanr::cmdstan_model()] for further details.
 #'
+#' @param cpp_options A list of options to pass to the `cpp_options` of
+#' [cmdstanr::cmdstan_model()]. By default nothing is passed but potentially
+#' users may wish to pass optimisation flags for example. See the documentation
+#' for [cmdstanr::cmdstan_model()] for further details. Note that the `threads`
+#' argument replaces `stan_threads`.
+#' 
 #' @param ... Additional arguments passed to [cmdstanr::cmdstan_model()].
 #'
 #' @return A `cmdstanr` model.
@@ -317,7 +323,8 @@ enw_model <- function(model = system.file(
                       ),
                       include = system.file("stan", package = "epinowcast"),
                       compile = TRUE, threads = FALSE, profile = FALSE,
-                      stanc_options = list(), verbose = TRUE,
+                      stanc_options = list(), cpp_options = list(),
+                      verbose = TRUE,
                       ...) {
   if (verbose) {
     message(sprintf("Using model %s.", model))
@@ -337,13 +344,12 @@ enw_model <- function(model = system.file(
         return(x)
       }
     }
+    cpp_options$stan_threads <- threads
     model <- monitor(cmdstanr::cmdstan_model(
       model,
       include_paths = include,
       stanc_options = stanc_options,
-      cpp_options = list(
-        stan_threads = threads
-      ),
+      cpp_options = cpp_options,
       ...
     ))
   }

--- a/man/enw_model.Rd
+++ b/man/enw_model.Rd
@@ -11,6 +11,7 @@ enw_model(
   threads = FALSE,
   profile = FALSE,
   stanc_options = list(),
+  cpp_options = list(),
   verbose = TRUE,
   ...
 )
@@ -35,8 +36,14 @@ For more on profiling see the \href{https://mc-stan.org/cmdstanr/articles/profil
 
 \item{stanc_options}{A list of options to pass to the \code{stanc_options} of
 \code{\link[cmdstanr:cmdstan_model]{cmdstanr::cmdstan_model()}}. By default nothing is passed but potentially
-users may wish to pass optimisation flags for example.See the documentation
+users may wish to pass optimisation flags for example. See the documentation
 for \code{\link[cmdstanr:cmdstan_model]{cmdstanr::cmdstan_model()}} for further details.}
+
+\item{cpp_options}{A list of options to pass to the \code{cpp_options} of
+\code{\link[cmdstanr:cmdstan_model]{cmdstanr::cmdstan_model()}}. By default nothing is passed but potentially
+users may wish to pass optimisation flags for example. See the documentation
+for \code{\link[cmdstanr:cmdstan_model]{cmdstanr::cmdstan_model()}} for further details. Note that the \code{threads}
+argument replaces \code{stan_threads}.}
 
 \item{verbose}{Logical, defaults to \code{TRUE}. Should verbose
 messages be shown.}

--- a/man/epinowcast.Rd
+++ b/man/epinowcast.Rd
@@ -9,8 +9,8 @@ epinowcast(
   reference = epinowcast::enw_reference(parametric = ~1, distribution = "lognormal",
     non_parametric = ~0, data = data),
   report = epinowcast::enw_report(non_parametric = ~0, structural = ~0, data = data),
-  expectation = epinowcast::enw_expectation(r = ~0 + (1 | day:.group), generation_time
-    = c(1), observation = ~1, latent_reporting_delay = c(1), data = data),
+  expectation = epinowcast::enw_expectation(r = ~0 + (1 | day:.group), generation_time =
+    c(1), observation = ~1, latent_reporting_delay = c(1), data = data),
   missing = epinowcast::enw_missing(formula = ~0, data = data),
   obs = epinowcast::enw_obs(family = "negbin", data = data),
   fit = epinowcast::enw_fit_opts(fit = epinowcast::enw_sample, nowcast = TRUE, pp =


### PR DESCRIPTION
This PR adds support for passing `cpp_options` this is useful for example when using GPU support (testing this out indicates it doesn't help on small scale models and in fact leads to a large slow down). 