### PR TITLE
Add target dir passing to enw_model

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@ a series of dates. Changed interface of `enw_preprocess_data()` to pass `...` to
 - Added support for right hand side interactions as syntax sugar for random effects. This allows the specification of, for example, independent random effects by day for each strata of another variable. See #169 by @seabbs.
 - Added support for passing `cpp_options` to `cmdstanr::cmdstan_model()`. See #182 by @seabbs.
 - Add functions for combining probability mass functions and constructing convolution matrices. See #183 by @seabbs.
+- Add a pass through from `enw_model()` to `write_stan_files_no_profile()` for the `target_dir` argument. This allows users to compile the model once and then share the compiled model across sessions rather than having to recompile each time the temporary directory is cleared. See #185 by @seabbs.
 
 ## Model
 - Added support for parametric log-logistic delay distributions. See #128 by @adrian-lison.

--- a/R/model-tools.R
+++ b/R/model-tools.R
@@ -314,6 +314,7 @@ enw_sample <- function(data, model = epinowcast::enw_model(),
 #'
 #' @family modeltools
 #' @export
+#' @inheritParams write_stan_files_no_profile
 #' @importFrom cmdstanr cmdstan_model
 #' @examplesIf interactive()
 #' mod <- enw_model()
@@ -323,16 +324,17 @@ enw_model <- function(model = system.file(
                       ),
                       include = system.file("stan", package = "epinowcast"),
                       compile = TRUE, threads = FALSE, profile = FALSE,
-                      stanc_options = list(), cpp_options = list(),
-                      verbose = TRUE,
-                      ...) {
+                      target_dir = tempdir(), stanc_options = list(),
+                      cpp_options = list(), verbose = TRUE, ...) {
   if (verbose) {
     message(sprintf("Using model %s.", model))
     message(sprintf("include is %s.", paste(include, collapse = ", ")))
   }
 
   if (!profile) {
-    stan_no_profile <- write_stan_files_no_profile(model, include)
+    stan_no_profile <- write_stan_files_no_profile(
+      model, include, target_dir =  target_dir
+    )
     model <- stan_no_profile$model
     include <- stan_no_profile$include_paths
   }

--- a/man/enw_model.Rd
+++ b/man/enw_model.Rd
@@ -10,6 +10,7 @@ enw_model(
   compile = TRUE,
   threads = FALSE,
   profile = FALSE,
+  target_dir = tempdir(),
   stanc_options = list(),
   cpp_options = list(),
   verbose = TRUE,
@@ -33,6 +34,11 @@ and \code{\link[=epinowcast]{epinowcast()}}.}
 
 \item{profile}{Logical, defaults to \code{FALSE}. Should the model be profiled?
 For more on profiling see the \href{https://mc-stan.org/cmdstanr/articles/profiling.html}{\code{cmdstanr} documentation}. # nolint}
+
+\item{target_dir}{The path to a directory in which the manipulated .stan
+files without profiling statements should be stored. To avoid overriding of
+the original .stan files, this should be different from the directory of the
+original model and the \code{include_paths}.}
 
 \item{stanc_options}{A list of options to pass to the \code{stanc_options} of
 \code{\link[cmdstanr:cmdstan_model]{cmdstanr::cmdstan_model()}}. By default nothing is passed but potentially


### PR DESCRIPTION
This PR adds the ability to pass the `target_dir` argument from `write_stan_files_no_profile` from `enw_model`. This is helpful when using the model in multiple R sessions and wanting to share a single compiled file. 
