### PR TITLE
Added a warning about empirical and specified delay being different

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -80,5 +80,5 @@ Encoding: UTF-8
 Language: en-GB
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3
 SystemRequirements: CmdStan (>=2.29)

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@ a series of dates. Changed interface of `enw_preprocess_data()` to pass `...` to
 - Add a functon, `convolution_matrix()` for constructing convolution matrices. See #183 by @seabbs.
 - Add a pass through from `enw_model()` to `write_stan_files_no_profile()` for the `target_dir` argument. This allows users to compile the model once and then share the compiled model across sessions rather than having to recompile each time the temporary directory is cleared. See #185 by @seabbs.
 - Added `add_pmfs()`, to sum probability mass functions into a new probability mass function. Initial implementation by @seabbs in #183, refactored by @pratikunterwegs in #187, following a suggestion in issue #186 by @pearsonca.
+- Added a warning when the observed empirical maximum delay is less than the specified maximum delay. See #190 by @seabbs.
 
 ## Model
 - Added support for parametric log-logistic delay distributions. See #128 by @adrian-lison.

--- a/R/epinowcast.R
+++ b/R/epinowcast.R
@@ -128,7 +128,7 @@ epinowcast <- function(data,
                          family = "negbin", data = data
                        ),
                        fit = epinowcast::enw_fit_opts(
-                         fit = epinowcast::enw_sample,
+                         sampler = epinowcast::enw_sample,
                          nowcast = TRUE, pp = FALSE,
                          likelihood = TRUE, debug = FALSE,
                          output_loglik = FALSE

--- a/R/preprocess.R
+++ b/R/preprocess.R
@@ -505,6 +505,10 @@ enw_delay_filter <- function(obs, max_delay) {
     ],
     by = c("reference_date", ".group")
   ]
+  empircal_max_delay <- obs[, max(delay, na.rm = TRUE)]
+  if (empircal_max_delay < (max_delay - 1)) {
+    warning("Empirical max delay is less than the specified max delay.")
+  }
   return(obs[])
 }
 

--- a/man/epinowcast.Rd
+++ b/man/epinowcast.Rd
@@ -13,7 +13,7 @@ epinowcast(
     c(1), observation = ~1, latent_reporting_delay = c(1), data = data),
   missing = epinowcast::enw_missing(formula = ~0, data = data),
   obs = epinowcast::enw_obs(family = "negbin", data = data),
-  fit = epinowcast::enw_fit_opts(fit = epinowcast::enw_sample, nowcast = TRUE, pp =
+  fit = epinowcast::enw_fit_opts(sampler = epinowcast::enw_sample, nowcast = TRUE, pp =
     FALSE, likelihood = TRUE, debug = FALSE, output_loglik = FALSE),
   model = epinowcast::enw_model(),
   priors,

--- a/tests/testthat/test-enw_delay_filter.R
+++ b/tests/testthat/test-enw_delay_filter.R
@@ -1,0 +1,10 @@
+test_that("enw_delay_filter can filter for delays as expected", {
+  obs <- enw_example("preprocessed")$obs[[1]]
+  expect_equal(max(enw_delay_filter(obs, max_delay = 2)$delay, na.rm = TRUE), 1)
+})
+
+test_that("enw_delay_filter throws a warning when the empirical delay is less
+           than the max specified", {
+  obs <- enw_example("preprocessed")$obs[[1]]
+  expect_warning(enw_delay_filter(obs, max_delay = 100))
+})

--- a/tests/testthat/test-epinowcast.R
+++ b/tests/testthat/test-epinowcast.R
@@ -28,6 +28,37 @@ test_that("epinowcast preprocesses data and model modules as expected", {
   expect_equal(nowcast[, c("init", "data") := NULL], pobs)
 })
 
+test_that("epinowcast runs using default arguments only", {
+  skip_on_cran()
+  skip_on_local()
+  obs <- germany_covid19_hosp[age_group %in% "00+"][location %in% "DE"] |>
+    enw_filter_report_dates(remove_days = 10) |>
+    enw_filter_reference_dates(include_days = 10)
+  pobs <- enw_preprocess_data(obs, max_delay = 5)
+  nowcast <- suppressMessages(epinowcast(pobs))
+  expect_equal(
+    setdiff(colnames(nowcast), colnames(pobs)),
+    c(
+      "fit", "data", "fit_args", "samples", "max_rhat",
+      "divergent_transitions", "per_divergent_transitions", "max_treedepth",
+      "no_at_max_treedepth", "per_at_max_treedepth", "run_time"
+    )
+  )
+  expect_equal(class(nowcast$fit[[1]])[1], "CmdStanMCMC")
+  expect_type(nowcast$fit_args[[1]], "list")
+  expect_type(nowcast$data[[1]], "list")
+  expect_lt(nowcast$per_divergent_transitions, 0.05)
+  expect_lt(nowcast$max_treedepth, 10)
+  expect_lt(nowcast$max_rhat, 1.05)
+  expect_error(
+    nowcast$fit[[1]]$summary(
+      c("refp_mean_int", "refp_sd_int")
+    ), NA
+  )
+  expect_error(nowcast$fit[[1]]$summary("refp_beta"))
+  expect_error(nowcast$fit[[1]]$summary("rep_beta"))
+})
+
 test_that("epinowcast can fit a simple reporting model", {
   skip_on_cran()
   skip_on_local()


### PR DESCRIPTION
This PR closes #167 by adding a warning when the maximum empirical delay is shorter than the specified maximum delay. It also adds unit tests for `enw_delay_filter` and adds a unit test to check that `epinowcast` fits as expected using its default settings (this catches a bug in the settings for `enw_fit_opts` that was caught whilst developing this PR.