### PR TITLE
compatibility with additional array notation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@ a series of dates. Changed interface of `enw_preprocess_data()` to pass `...` to
 - Add a pass through from `enw_model()` to `write_stan_files_no_profile()` for the `target_dir` argument. This allows users to compile the model once and then share the compiled model across sessions rather than having to recompile each time the temporary directory is cleared. See #185 by @seabbs.
 - Added `add_pmfs()`, to sum probability mass functions into a new probability mass function. Initial implementation by @seabbs in #183, refactored by @pratikunterwegs in #187, following a suggestion in issue #186 by @pearsonca.
 - Added a warning when the observed empirical maximum delay is less than the specified maximum delay. See #190 by @seabbs.
+- Added nested support for converting array syntax in `convert_cmdstan_to_rstan`. See #192 by @sbfnk.
 
 ## Model
 - Added support for parametric log-logistic delay distributions. See #128 by @adrian-lison.

--- a/R/utils.R
+++ b/R/utils.R
@@ -40,7 +40,7 @@ convert_cmdstan_to_rstan <- function(functions) {
   #   case 1a: array[] real x -> real[] x
   functions <- gsub(
     "array\\[(,?)\\] ([^ ]*) ([a-z_]+)", "\\2[\\1] \\3", functions  )
-  #   case 1b: array[n] real x -> real x[n], including the nexted case
+  #   case 1b: array[n] real x -> real x[n], including the nested case
   functions <- gsub(
     "array\\[([a-z0-9_]+(\\[[^]]*\\])?)\\] ([^ ]*) ([a-z_]+)",
     "\\3 \\4[\\1]", functions

--- a/R/utils.R
+++ b/R/utils.R
@@ -37,9 +37,13 @@ convert_cmdstan_to_rstan <- function(functions) {
   # replace lupmf with lpmf
   functions <- gsub("_lupmf", "_lpmf", functions)
   # replace array syntax
-  #   case 1: array[] real x -> real[] x
+  #   case 1a: array[] real x -> real[] x
   functions <- gsub(
-    "array\\[(,?)\\] (.*) ([a-z_]+)", "\\2[\\1] \\3", functions
+    "array\\[(,?)\\] ([^ ]*) ([a-z_]+)", "\\2[\\1] \\3", functions  )
+  #   case 1b: array[n] real x -> real x[n], including the nexted case
+  functions <- gsub(
+    "array\\[([a-z0-9_]+(\\[[^]]*\\])?)\\] ([^ ]*) ([a-z_]+)",
+    "\\3 \\4[\\1]", functions
   )
   #   case 2: array[n] real x -> real x[n]
   functions <- gsub(

--- a/R/utils.R
+++ b/R/utils.R
@@ -39,7 +39,8 @@ convert_cmdstan_to_rstan <- function(functions) {
   # replace array syntax
   #   case 1a: array[] real x -> real[] x
   functions <- gsub(
-    "array\\[(,?)\\] ([^ ]*) ([a-z_]+)", "\\2[\\1] \\3", functions  )
+    "array\\[(,?)\\] ([^ ]*) ([a-z_]+)", "\\2[\\1] \\3", functions
+  )
   #   case 1b: array[n] real x -> real x[n], including the nested case
   functions <- gsub(
     "array\\[([a-z0-9_]+(\\[[^]]*\\])?)\\] ([^ ]*) ([a-z_]+)",


### PR DESCRIPTION
Updates `convert_cmdstan_to_rstan` to deal with some previously unsupported array notation. 

This may address the issue mentioned in https://github.com/epinowcast/epinowcast/issues/174#issuecomment-1356889203.