### PR TITLE
Force numeric for prediction and true value when scoring

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: epinowcast
 Title: Flexible Hierarchical Nowcasting
-Version: 0.2.0.1000
+Version: 0.2.0.2000
 Authors@R:
   c(person(given = "Sam Abbott",
            role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
-# epinowcast 0.2.0.1000
+# epinowcast 0.2.0.2000
 
-This is release is in development. It is not yet ready for production use.
+This is release is in development. It is not yet ready for production use. If you notice problems please report them on the [issue tracker](https://github.com/epinowcast/epinowcast/issues).
+
+## Bugs
+
+- Fixed an issue (#198) with the interface for `scoringutils`. For an unknown reason our example data contained `pillar` classes (likely due to an upstream change). This caused an issue with internal `scoringutils` that was using implict type conversion (see [here]()). See #201 by @seabbs.
 
 # epinowcast 0.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@ This is release is in development. It is not yet ready for production use. If yo
 
 ## Bugs
 
-- Fixed an issue (#198) with the interface for `scoringutils`. For an unknown reason our example data contained `pillar` classes (likely due to an upstream change). This caused an issue with internal `scoringutils` that was using implict type conversion (see [here]()). See #201 by @seabbs.
+- Fixed an issue (#198) with the interface for `scoringutils`. For an unknown reason our example data contained `pillar` classes (likely due to an upstream change). This caused an issue with internal `scoringutils` that was using implict type conversion (see [here](https://github.com/epiforecasts/scoringutils/pull/274)). See #201 by @seabbs and reviewed by @pearsonca.
 
 # epinowcast 0.2.0
 

--- a/R/model-validation.R
+++ b/R/model-validation.R
@@ -71,12 +71,12 @@ enw_score_nowcast <- function(nowcast, latest_obs, log = FALSE,
     long_nowcast[, (cols) := purrr::map(.SD, ~ log(. + 0.01)), .SDcols = cols]
   }
 
+  long_nowcast[, prediction := as.numeric(prediction)]
+  long_nowcast[, true_value := as.numeric(true_value)]
+
   if (check) {
     scoringutils::check_forecasts(long_nowcast)
   }
-
-  long_nowcast[, prediction := as.numeric(prediction)]
-  long_nowcast[, true_value := as.numeric(true_value)]
 
   scores <- scoringutils::score(long_nowcast, ...)
   numeric_cols <- colnames(scores)[sapply(scores, is.numeric)]

--- a/R/model-validation.R
+++ b/R/model-validation.R
@@ -75,6 +75,9 @@ enw_score_nowcast <- function(nowcast, latest_obs, log = FALSE,
     scoringutils::check_forecasts(long_nowcast)
   }
 
+  long_nowcast[, prediction := as.numeric(prediction)]
+  long_nowcast[, true_value := as.numeric(true_value)]
+
   scores <- scoringutils::score(long_nowcast, ...)
   numeric_cols <- colnames(scores)[sapply(scores, is.numeric)]
   scores <- scores[, (numeric_cols) := lapply(.SD, signif, digits = round_to),


### PR DESCRIPTION
This PR closes #198 by forcing the conversion of `true_value` and `prediction` as indicated by @nikosbosse (the author of `scoringutils`) as the likely fix. 

It also increments the dev version and adds a news item (the review might consider adding a reviewed by tag to this once their review is complete). 

The following code now works as expected and package tests are passing. 

```r
library(epinowcast)
 
     nowcast <- enw_example("nowcast")
     summarised_nowcast <- summary(nowcast)
     obs <- enw_example("observations")
 
    enw_score_nowcast(summarised_nowcast, obs)
```