### PR TITLE
Add unit tests for check_ functions and remove internal plots

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,8 +10,8 @@ This is release is in development. It is not yet ready for production use. If yo
 - Resolved the spurious test warnings for snapshot tests which were linked to unstated formatting requirements. See #208 by @seabbs and reviewed by @pearsonca.
 - Added a new internal `check_by` function as suggested by @pearsonca. This checks that user suggested grouping variables exist in the supplied data and returns an informative error if they do not. See #208 by @seabbs and reviewed by @pearsonca.
 - Deprecated and removed `enw_dates_to_factors` as no longer needed. See #216 by @seabbs and reviewed by @adrian-lison.
-- Removed unused internal plot helpers. See #217 by @seabbs and reviewed by .
-- Added tests for all internal `check_` functions used to check inputs. See #217 by @seabbs and reviewed by .
+- Removed unused internal plot helpers. See #217 by @seabbs and reviewed by @adrian-lison.
+- Added tests for all internal `check_` functions used to check inputs. See #217 by @seabbs and reviewed by @adrian-lison.
 
 ## Documentation
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,8 @@ This is release is in development. It is not yet ready for production use. If yo
 - Resolved the spurious test warnings for snapshot tests which were linked to unstated formatting requirements. See #208 by @seabbs and reviewed by @pearsonca.
 - Added a new internal `check_by` function as suggested by @pearsonca. This checks that user suggested grouping variables exist in the supplied data and returns an informative error if they do not. See #208 by @seabbs and reviewed by @pearsonca.
 - Deprecated and removed `enw_dates_to_factors` as no longer needed. See #216 by @seabbs and reviewed by @adrian-lison.
-
+- Removed unused internal plot helpers. See #216 by @seabbs and reviewed by @adrian-lison.
+- Added tests for all internal `check_` functions used to check inputs. See #216 by @seabbs and reviewed by @adrian-lison.
 ## Documentation
 
 - Added examples for `summary.epinowcast()` and `plot.epinowcast()` methods to the documentation. See #209 by @seabbs and reviewed by @pearsonca.

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,8 +10,9 @@ This is release is in development. It is not yet ready for production use. If yo
 - Resolved the spurious test warnings for snapshot tests which were linked to unstated formatting requirements. See #208 by @seabbs and reviewed by @pearsonca.
 - Added a new internal `check_by` function as suggested by @pearsonca. This checks that user suggested grouping variables exist in the supplied data and returns an informative error if they do not. See #208 by @seabbs and reviewed by @pearsonca.
 - Deprecated and removed `enw_dates_to_factors` as no longer needed. See #216 by @seabbs and reviewed by @adrian-lison.
-- Removed unused internal plot helpers. See #216 by @seabbs and reviewed by @adrian-lison.
-- Added tests for all internal `check_` functions used to check inputs. See #216 by @seabbs and reviewed by @adrian-lison.
+- Removed unused internal plot helpers. See #217 by @seabbs and reviewed by .
+- Added tests for all internal `check_` functions used to check inputs. See #217 by @seabbs and reviewed by .
+
 ## Documentation
 
 - Added examples for `summary.epinowcast()` and `plot.epinowcast()` methods to the documentation. See #209 by @seabbs and reviewed by @pearsonca.

--- a/R/check.R
+++ b/R/check.R
@@ -11,7 +11,7 @@
 #' @family check
 check_quantiles <- function(posterior, req_probs = c(0.5, 0.95, 0.2, 0.8)) {
   cols <- colnames(posterior)
-  if (sum(cols %in% c("q5", "q95", "q20", "q80")) != 4) {
+  if (sum(cols %in% paste0("q", req_probs * 100)) != length(req_probs)) {
     stop(
       "Following quantiles must be present (set with probs): ",
       paste(req_probs, collapse = ", ")

--- a/R/check.R
+++ b/R/check.R
@@ -10,6 +10,9 @@
 #'
 #' @family check
 check_quantiles <- function(posterior, req_probs = c(0.5, 0.95, 0.2, 0.8)) {
+  if (any(req_probs <= 0) || any(req_probs >= 1)) {
+    stop("Please provide probabilities as numbers between 0 and 1.")
+  }
   cols <- colnames(posterior)
   if (sum(cols %in% paste0("q", req_probs * 100)) != length(req_probs)) {
     stop(

--- a/R/plot.R
+++ b/R/plot.R
@@ -70,17 +70,6 @@ enw_plot_obs <- function(obs, latest_obs = NULL, log = TRUE, ...) {
   return(plot)
 }
 
-enw_plot_obs_by_reference <- function(obs, latest_obs, log = TRUE, ...) {
-  enw_plot_obs(obs, latest_obs, log = log, ...) +
-    labs(y = "Notifications", x = "Reference date")
-}
-
-enw_plot_obs_by_report <- function(obs, log = TRUE, ...) {
-  enw_plot_obs(obs, log = log, ...) +
-    labs(y = "Notifications", x = "Report date")
-}
-
-
 #' Generic quantile plot
 #'
 #' @param posterior A `data.frame` of summarised posterior estimates

--- a/R/plot.R
+++ b/R/plot.R
@@ -76,7 +76,7 @@ enw_plot_obs <- function(obs, latest_obs = NULL, log = TRUE, ...) {
 #' containing at least a `confirm` count column a date variable,
 #' quantile estimates for the 5%, 20%, 80%, and 95% quantiles and the
 #' mean and median. This function is wrapped in
-#' [enw_plot_nowcast_quantiles()] and [enw_plot_pp_quantiles()] with sensible 
+#' [enw_plot_nowcast_quantiles()] and [enw_plot_pp_quantiles()] with sensible
 #' default labels.
 #'
 #' @return A `ggplot2` plot.

--- a/tests/testthat/test-check_by.R
+++ b/tests/testthat/test-check_by.R
@@ -2,6 +2,7 @@ test_that("check_by works as expected", {
   expect_equal(check_by(mtcars), NULL)
   expect_equal(check_by(mtcars, by = "cyl"), NULL)
   expect_equal(check_by(mtcars, by = c("mpg", "cyl")), NULL)
+  expect_error(check_by(mtcars, by = 2))
   expect_error(check_by(mtcars, by = c("fwfw")))
   expect_error(check_by(mtcars, by = c("fwfwfwe", "fwefwe")))
   expect_error(check_by(mtcars, by = c("fwfwfwe", "mpg")))

--- a/tests/testthat/test-check_modules_compatible.R
+++ b/tests/testthat/test-check_modules_compatible.R
@@ -1,0 +1,9 @@
+test_that("check_modules_compatible works as expected", {
+  modules <- as.list(rep(1, 6))
+  modules[[4]] <- list(data = list(model_miss = FALSE))
+  modules[[6]] <- list(data = list(likelihood_aggregation = FALSE))
+  expect_equal(epinowcast:::check_modules_compatible(modules), NULL)
+  modules[[4]] <- list(data = list(model_miss = TRUE))
+  modules[[6]] <- list(data = list(likelihood_aggregation = FALSE))
+  expect_warning(epinowcast:::check_modules_compatible(modules))
+})

--- a/tests/testthat/test-check_quantiles.R
+++ b/tests/testthat/test-check_quantiles.R
@@ -1,0 +1,7 @@
+test_that("check_quantiles works as expected", {
+  dt <- data.frame(q50 = 1, q95 = 1, q20 = 1, q80 = 1)
+  expect_equal(epinowcast:::check_quantiles(dt), NULL)
+  expect_equal(epinowcast:::check_quantiles(dt, req_probs = 0.2), NULL)
+  expect_error(epinowcast:::check_quantiles(dt, req_probs = 0.35))
+  expect_error(epinowcast:::check_quantiles(dt, req_probs =c(0.2, 0.35)))
+})

--- a/tests/testthat/test-check_quantiles.R
+++ b/tests/testthat/test-check_quantiles.R
@@ -4,4 +4,5 @@ test_that("check_quantiles works as expected", {
   expect_equal(epinowcast:::check_quantiles(dt, req_probs = 0.2), NULL)
   expect_error(epinowcast:::check_quantiles(dt, req_probs = 0.35))
   expect_error(epinowcast:::check_quantiles(dt, req_probs =c(0.2, 0.35)))
+  expect_error(epinowcast:::check_quantiles(dt, req_probs = 35))
 })


### PR DESCRIPTION
This PR increases test coverage by adding unit tests for `check_` functions where missing. In adding these tests I noticed that `check_quantiles` was not as flexible as originally intended so I have refactored. 

I have also removed two internal plot functions that were not be used and were untested.