### PR TITLE
Disable lint workflow on pushes

### DIFF
--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -1,11 +1,6 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
-  push:
-    branches:
-      - main
-      - master
-      - develop
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Since this workflow is set up to run on files modified in a PR, it doesn't make sense to have it run in pushes (and it will fail). It's not an issue since all changes are done via PR so you are sure that this workflow will still always run on new code.