### PR TITLE
Do not use else after stop()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: epinowcast
 Title: Flexible Hierarchical Nowcasting
-Version: 0.2.0.9000
+Version: 0.2.0.10000
 Authors@R:
   c(person(given = "Sam Abbott",
            role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,8 +10,8 @@ This is release is in development. It is not yet ready for production use. If yo
 ## Package
 
 - Fixed some typos in `README.md`, `NEWS.md`, the `model.Rmd` vignette and `convolution_matrix()` documentation. The `WORDLIST` used by spelling has also been updated by eliminate false positives. See #221 by @Bisaloo and reviewed by @seabbs and @adrian-lison.
-- Added more non-default linters in `.lintr` configuration file. This file is used when `lintr::lint_package()` is run or in the new `lint-changed-files.yaml` GitHub Actions workflow. See #220 by @Bisaloo and reviewed by @pearsonca and @seeabs.
-- Switched to the `lint-changed-files.yaml` GitHub Actions workflow instead of the regular `lint.yaml` to avoid annotations unrelated to the changes made in the PR. See #220 by @Bisaloo and reviewed by @pearsonca and @seeabs.
+- Added more non-default linters in `.lintr` configuration file. This file is used when `lintr::lint_package()` is run or in the new `lint-changed-files.yaml` GitHub Actions workflow. See #220 by @Bisaloo and reviewed by @pearsonca and @seabbs.
+- Switched to the `lint-changed-files.yaml` GitHub Actions workflow instead of the regular `lint.yaml` to avoid annotations unrelated to the changes made in the PR. See #220 by @Bisaloo and reviewed by @pearsonca and @seabbs.
 - Added tests for `summary.epinowcast()` and `plot.epinowcast()` methods. See #209 by @seabbs and reviewed by @pearsonca.
 - Added tests for `enw_plot_obs()` where not otherwise covered by `plot.epinowcast()` tests. See #209 by @seabbs and reviewed by @pearsonca.
 - Made the `.group` variable optional for all preprocessing functions using a new `add_group()` internal function. See #208 by @seabbs and reviewed by @pearsonca.

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@ This is release is in development. It is not yet ready for production use. If yo
 - Removed unused internal plot helpers. See #217 by @seabbs and reviewed by @adrian-lison.
 - Added tests for all internal `check_` functions used to check inputs. See #217 by @seabbs and reviewed by @adrian-lison.
 - Removed the problematic double specification of default arguments for `target_date` in `enw_metadata()` as flagged in #212 by @pearsonca using `formals()` to instead detect the default values from the function specification. See #232 by @seabbs and self-reviewed.
+- In the words of Jenny Bryan: "there is no else, there is only if." Having else after `return()` of `stop()` increases the number of branches in the code, which makes it harder to read. It also translates into a higher cyclomatic complexity. We have removed all else statements after `return()` and `stop()` in the package. See #229 by @Bisaloo and reviewed by @seabbs.
 
 ## Documentation
 

--- a/R/check.R
+++ b/R/check.R
@@ -41,9 +41,11 @@ check_dates <- function(obs) {
       "Both reference_date and report_date must be present in order to use this
       function"
     )
-  } else if (is.null(obs$reference_date)) {
+  }
+  if (is.null(obs$reference_date)) {
     stop("reference_date must be present")
-  } else if (is.null(obs$report_date)) {
+  }
+  if (is.null(obs$report_date)) {
     stop("report_date must be present")
   }
   obs[, report_date := as.IDate(report_date)]
@@ -65,12 +67,14 @@ check_group <- function(obs) {
       ".group is a reserved variable and must not be present in the input
        data"
     )
-  } else if (!is.null(obs$.new_group)) {
+  }
+  if (!is.null(obs$.new_group)) {
     stop(
       ".new_group is a reserved variable and must not be present in the input
        data"
     )
-  } else if (!is.null(obs$.old_group)) {
+  }
+  if (!is.null(obs$.old_group)) {
     stop(
       ".old_group is a reserved variable and must not be present in the input
        data"

--- a/R/preprocess.R
+++ b/R/preprocess.R
@@ -124,7 +124,8 @@ enw_add_metaobs_features <- function(metaobs,
   metaobs <- data.table::as.data.table(metaobs)
   if (is.null(metaobs[[datecol]])) {
     stop(sprintf("metaobs does not have datecol '%s'.", datecol))
-  } else if (!is.Date(metaobs[[datecol]])) {
+  }
+  if (!is.Date(metaobs[[datecol]])) {
     stop(sprintf("metaobs column '%s' is not a Date.", datecol))
   }
 


### PR DESCRIPTION
In the words of Jenny Bryan: "there is no else, there is only if."

https://speakerdeck.com/jennybc/code-smells-and-feels?slide=45

Having `else` after `return()` of `stop()` increases the number of branches in the code, which makes it harder to read. It also translates into a higher cyclomatic complexity.