### PR TITLE
`enw_metadata()` `target_date` default be detected from the function specification

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: epinowcast
 Title: Flexible Hierarchical Nowcasting
-Version: 0.2.0.8000
+Version: 0.2.0.9000
 Authors@R:
   c(person(given = "Sam Abbott",
            role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,7 +19,7 @@ This is release is in development. It is not yet ready for production use. If yo
 - Added a new internal `check_by` function as suggested by @pearsonca. This checks that user suggested grouping variables exist in the supplied data and returns an informative error if they do not. See #208 by @seabbs and reviewed by @pearsonca.
 - Removed unused internal plot helpers. See #217 by @seabbs and reviewed by @adrian-lison.
 - Added tests for all internal `check_` functions used to check inputs. See #217 by @seabbs and reviewed by @adrian-lison.
-- Removed the problematic double specification of default arguments for `target_date` in `enw_metadata()` as flagged in #212 by @pearsonca using `formals()` to instead detect the default values from the function specification. See by @seabbs and reviewed by @pearsonca.
+- Removed the problematic double specification of default arguments for `target_date` in `enw_metadata()` as flagged in #212 by @pearsonca using `formals()` to instead detect the default values from the function specification. See #232 by @seabbs and self-reviewed.
 
 ## Documentation
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@ This is release is in development. It is not yet ready for production use. If yo
 - Added a new internal `check_by` function as suggested by @pearsonca. This checks that user suggested grouping variables exist in the supplied data and returns an informative error if they do not. See #208 by @seabbs and reviewed by @pearsonca.
 - Removed unused internal plot helpers. See #217 by @seabbs and reviewed by @adrian-lison.
 - Added tests for all internal `check_` functions used to check inputs. See #217 by @seabbs and reviewed by @adrian-lison.
+- Removed the problematic double specification of default arguments for `target_date` in `ennw_metadata()` as flagged in #212 by @pearsonca using `formals()` to instead detect the default values from the function specification. See by @seabbs and reviewed by.
 
 ## Documentation
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,7 +19,7 @@ This is release is in development. It is not yet ready for production use. If yo
 - Added a new internal `check_by` function as suggested by @pearsonca. This checks that user suggested grouping variables exist in the supplied data and returns an informative error if they do not. See #208 by @seabbs and reviewed by @pearsonca.
 - Removed unused internal plot helpers. See #217 by @seabbs and reviewed by @adrian-lison.
 - Added tests for all internal `check_` functions used to check inputs. See #217 by @seabbs and reviewed by @adrian-lison.
-- Removed the problematic double specification of default arguments for `target_date` in `ennw_metadata()` as flagged in #212 by @pearsonca using `formals()` to instead detect the default values from the function specification. See by @seabbs and reviewed by.
+- Removed the problematic double specification of default arguments for `target_date` in `enw_metadata()` as flagged in #212 by @pearsonca using `formals()` to instead detect the default values from the function specification. See by @seabbs and reviewed by @pearsonca.
 
 ## Documentation
 

--- a/R/preprocess.R
+++ b/R/preprocess.R
@@ -25,7 +25,10 @@
 #' @export
 #' @importFrom data.table as.data.table
 #' @examples
-#' obs <- data.frame(reference_date = as.Date("2021-01-01"), x = 1:10)
+#' obs <- data.frame(
+#'  reference_date = as.Date("2021-01-01"),
+#'  report_date = as.Date("2022-01-01"), x = 1:10
+#' )
 #' enw_metadata(obs, target_date = "reference_date")
 enw_metadata <- function(obs, target_date = c(
                            "reference_date", "report_date"

--- a/R/preprocess.R
+++ b/R/preprocess.R
@@ -31,7 +31,7 @@ enw_metadata <- function(obs, target_date = c(
                            "reference_date", "report_date"
                          )) {
   obs <- data.table::as.data.table(obs)
-  choices <- c("reference_date", "report_date")
+  choices <- eval(formals()$target_date)
   target_date <- match.arg(target_date)
   date_to_drop <- setdiff(choices, target_date)
 

--- a/man/enw_metadata.Rd
+++ b/man/enw_metadata.Rd
@@ -32,7 +32,10 @@ by reference or by report date. For the target date chosen
 are dropped and the first observation for each group and date is retained.
 }
 \examples{
-obs <- data.frame(reference_date = as.Date("2021-01-01"), x = 1:10)
+obs <- data.frame(
+ reference_date = as.Date("2021-01-01"),
+ report_date = as.Date("2022-01-01"), x = 1:10
+)
 enw_metadata(obs, target_date = "reference_date")
 }
 \seealso{

--- a/man/epinowcast-package.Rd
+++ b/man/epinowcast-package.Rd
@@ -19,19 +19,21 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Sam Abbott \email{sam.abbott@lshtm.ac.uk} (\href{https://orcid.org/0000-0001-8057-8037}{ORCID})
+\strong{Maintainer}: Sam Abbott \email{contact@samabbott.co.uk} (\href{https://orcid.org/0000-0001-8057-8037}{ORCID})
 
 Authors:
 \itemize{
   \item Adrian Lison \email{adrian.lison@bsse.ethz.ch} (\href{https://orcid.org/0000-0002-6822-8437}{ORCID})
   \item Sebastian Funk \email{sebastian.funk@lshtm.ac.uk}
   \item Carl Pearson \email{carl.ab.pearson@gmail.com} (\href{https://orcid.org/0000-0003-0701-7860}{ORCID})
+  \item Hugo Gruson \email{hugo.gruson@normalesup.org} (\href{https://orcid.org/0000-0002-4094-1476}{ORCID})
 }
 
 Other contributors:
 \itemize{
   \item Michael DeWitt \email{me.dewitt.jr@gmail.com} (\href{https://orcid.org/0000-0001-8940-1967}{ORCID}) [contributor]
   \item Hannah Choi \email{hannah.choi1@lshtm.ac.uk} [contributor]
+  \item Pratik Gupte \email{pratik.gupte@lshtm.ac.uk} (\href{https://orcid.org/0000-0001-5294-7819}{ORCID}) [contributor]
 }
 
 }

--- a/tests/testthat/test-enw_metadata.R
+++ b/tests/testthat/test-enw_metadata.R
@@ -1,9 +1,9 @@
-#' obs <- data.frame(reference_date = as.Date("2021-01-01"), x = 1:10)
-#' enw_metadata(obs, target_date = "reference_date")
-#' 
-
 test_that("enw_metadata works as expected", {
-  obs <- data.frame(reference_date = as.Date("2021-01-01"), x = 1:10)
+  obs <- data.frame(
+    reference_date = as.Date("2021-01-01"),
+    report_date = as.Date("2022-01-01"),
+    x = 1:10
+  )
   expect_equal(
     enw_metadata(obs, target_date = "reference_date"),
     data.table::setkeyv(
@@ -18,13 +18,33 @@ test_that("enw_metadata works as expected", {
 test_that(
   "enw_metadata works as expected when a grouping variable is present", {
   obs <- data.frame(
-    reference_date = as.Date("2021-01-01"), x = 1:10, .group = 2
+    reference_date = as.Date("2021-01-01"),
+    report_date = as.Date("2022-01-01"),
+    x = 1:10,
+    .group = 2
   )
   expect_equal(
     enw_metadata(obs, target_date = "reference_date"),
     data.table::setkeyv(
       data.table::data.table(
         date = as.Date("2021-01-01"), .group = 2, x = 1
+      ),
+      c(".group","date")
+    )
+  )
+}) 
+
+test_that("enw_metadata works as expected to summarise report_date metadata", {
+  obs <- data.frame(
+    reference_date = as.Date("2021-01-01"),
+    report_date = as.Date("2022-01-01"),
+    x = 1:10, y = 1:10
+  )
+  expect_equal(
+    enw_metadata(obs, target_date = "report_date"),
+    data.table::setkeyv(
+      data.table::data.table(
+        date = as.Date("2022-01-01"), .group = 1, x = 1, y = 1
       ),
       c(".group","date")
     )


### PR DESCRIPTION
This PR closes #212 by detecting the defaults for `target_date` from the function specification using `formals()`. 