### PR TITLE
Issue 246: Correct initial conditions for r intercept + revert CI to latest cmdstan

### DIFF
--- a/.github/actions/touchstone-recieve/action.yaml
+++ b/.github/actions/touchstone-recieve/action.yaml
@@ -103,7 +103,7 @@ runs:
       run: |
         print(list.files("C:/rtools42"))
         cmdstanr::check_cmdstan_toolchain(fix = TRUE)
-        cmdstanr::install_cmdstan(cores = 2, quiet = TRUE, version = "2.31.0")
+        cmdstanr::install_cmdstan(cores = 2, quiet = TRUE)
       shell: Rscript {0}
     - name: Remove global installation
       run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -77,7 +77,7 @@ jobs:
         run: |
           print(list.files("C:/rtools42"))
           cmdstanr::check_cmdstan_toolchain(fix = TRUE)
-          cmdstanr::install_cmdstan(cores = 2, quiet = TRUE, version = "2.31.0")
+          cmdstanr::install_cmdstan(cores = 2, quiet = TRUE)
         shell: Rscript {0}
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Install cmdstan
         run: |
           cmdstanr::check_cmdstan_toolchain(fix = TRUE)
-          cmdstanr::install_cmdstan(cores = 2, quiet = TRUE, version = "2.31.0")
+          cmdstanr::install_cmdstan(cores = 2, quiet = TRUE)
         shell: Rscript {0}
 
       - name: Build site

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -33,7 +33,7 @@ jobs:
         run: |
           print(list.files("C:/rtools42"))
           cmdstanr::check_cmdstan_toolchain(fix = TRUE)
-          cmdstanr::install_cmdstan(cores = 2, quiet = TRUE, version = "2.31.0")
+          cmdstanr::install_cmdstan(cores = 2, quiet = TRUE)
         shell: Rscript {0}
 
       - name: Test coverage

--- a/R/model-modules.R
+++ b/R/model-modules.R
@@ -382,9 +382,7 @@ enw_expectation <- function(r = ~ 0 + (1 | day:.group), generation_time = 1,
           ),
           nrow = data$expr_gt_n
         )),
-        expr_r_int = rnorm(
-          1, priors$expr_r_int[1], priors$expr_r_int[2] * 0.1
-        ),
+        expr_r_int = numeric(0),
         expl_beta = numeric(0),
         expl_beta_sd = numeric(0)
       )
@@ -396,6 +394,11 @@ enw_expectation <- function(r = ~ 0 + (1 | day:.group), generation_time = 1,
           data$expr_rncol, priors$expr_beta_sd_p[1],
           priors$expr_beta_sd_p[2] / 10
         ))
+      }
+      if (data$expr_fintercept > 0) {
+        init$expr_r_int <- rnorm(
+          1, priors$expr_r_int[1], priors$expr_r_int[2] * 0.1
+        )
       }
       if (data$expl_fncol > 0) {
         init$expl_beta <- rnorm(data$expl_fncol, 0, 0.01)


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #246.

#246 flagged a range of models failing due to an opaque `stan` error. As flagged in that issue this comes down to inappropriately passing an initial condition with some size to one of the unused parameters. 

So far I have found just one instance of this: `expr_r_int` which was still being passed as an initial condition when no intercept was used. The CI in this PR may flag more instances and I will review the code as an additional check (check mark below).

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [x] I have read the [contribution guidelines](https://github.com/epinowcast/epinowcast/blob/main/CONTRIBUTING.md).
- [x] I have tested my changes locally.
- [x] I have updated the documentation if required.
- [x] My code follows the established coding standards.
- [ ] I have reviewed the code for other potential issues of a similar kind.
- [ ] I have added a news item linked to this PR.
- [ ] I have updated the package development version by one increment in both `NEWS.md` and the `DESCRIPTION`.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
