### PR TITLE
Issue 278: minor improvements to the discrete delay distributions vignette

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: epinowcast
 Title: Flexible Hierarchical Nowcasting
-Version: 0.2.2.1000
+Version: 0.2.2.2000
 Authors@R:
   c(person(given = "Sam Abbott",
            role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,16 +1,22 @@
 # epinowcast 0.2.2
 
-This release is in development and therefore not ready for production use.
+This release is in development and not ready for production use.
 
 ## Contributors
 
-@seabbs contributed code to this release.
+@sbfnk and @seabbs contributed code to this release.
 
-@seabbs reported bugs reported bugs, made suggestions, or contributed to discussions that led to improvements in this release.
+@seabbs reviewed pull requests for this release.
 
-## Bug
+@sbfnk and @seabbs reported bugs reported bugs, made suggestions, or contributed to discussions that led to improvements in this release.
+
+## Bugs
 
 - Improved the handling of optional initial conditions so that they are consistently passed as arrays to stan as required by `cmdstan 2.32.1`. This fix is required in order to use versions of `cmdstan` beyond `2.32.0`. See #276 by @seabbs and self-reviewed.
+
+## Documentation
+
+- Improved the discrete delay distributions vignette including escaping functions to improve readibility and right-closing discretised bins. See #275 by @sbfnk and reviewed by @seabbs.
 
 # epinowcast 0.2.1
 

--- a/vignettes/distributions.Rmd
+++ b/vignettes/distributions.Rmd
@@ -30,7 +30,7 @@ In `epinowcast`, delays are modeled in discrete time and with an assumed maximum
 
 To discretise the continuous probability distribution into discrete probabilities $p^{\prime}_{g,t,d}$, we use its cumulative distribution function $F^{\mu_{g,t}, \upsilon_{g,t}}$ to compute
 $$p^{\prime}_{g,t,d} = \frac{F^{\mu_{g,t}, \upsilon_{g,t}}(d+1) - F^{\mu_{g,t}, \upsilon_{g,t}}(d)}{F^{\mu_{g,t}, \upsilon_{g,t}}(D)}.$$
-In words, the discrete probability mass function (pmf) is obtained from the continuous distribution by dividing it into $D$ different bins $$(0,1),\, (1,2),\, \ldots,\, (D-1,D),$$
+In words, the discrete probability mass function (pmf) is obtained from the continuous distribution by dividing it into $D$ different bins $$(0,1],\, (1,2],\, \ldots,\, (D-1,D],$$
 where $D$ is the maximum delay covered by the model. Importantly, the bins are normalized by $F^{\mu_{g,t}, \upsilon_{g,t}}(D)$, which ensures that the $p^{\prime}_{g,t,d}$ sum to 1. Since $F^{\mu_{g,t}, \upsilon_{g,t}}(D)$ is the probability of reporting before the maximum delay, this can also be interpreted as conditioning our distribution on the maximum delay.
 
 Note that because of the discretisation and normalization, the discrete random variable we obtain generally does not have exactly the same moments as the original, continuous distribution.

--- a/vignettes/distributions.Rmd
+++ b/vignettes/distributions.Rmd
@@ -19,10 +19,10 @@ The currently available parametric delay distributions are continuous probabilit
 
 | Distribution 	| Parametrization | Mean |
 | :--------------:	| :------------:  | :------------------:	|
-| [Log-normal](https://mc-stan.org/docs/functions-reference/lognormal.html)  | $\mu=\mu_{g,t}$, $\sigma = \upsilon_{g,t}$	| $exp(\mu_{g,t}+\frac{\upsilon_{g,t}^2}{2})$ 	|
-| [Exponential](https://mc-stan.org/docs/functions-reference/exponential-distribution.html)  | $\beta = exp(-\mu_{g,t})$	| $exp(\mu_{g,t})$ |
-| [Gamma](https://mc-stan.org/docs/functions-reference/gamma-distribution.html)        |	$\alpha = exp(\mu_{g,t})$, $\beta = \upsilon_{g,t}$ | $exp(\mu_{g,t})/\upsilon_{g,t}$ |
-| [Log-logistic](https://en.wikipedia.org/wiki/Log-logistic_distribution) |	$\alpha = exp(\mu_{g,t})$, $\beta = \upsilon_{g,t}$ | $\frac{exp(\mu_{g,t})\,\pi/\upsilon_{g,t}}{sin(\pi/\upsilon_{g,t})}$ |
+| [Log-normal](https://mc-stan.org/docs/functions-reference/lognormal.html)  | $\mu=\mu_{g,t}$, $\sigma = \upsilon_{g,t}$	| $\exp(\mu_{g,t}+\frac{\upsilon_{g,t}^2}{2})$ 	|
+| [Exponential](https://mc-stan.org/docs/functions-reference/exponential-distribution.html)  | $\beta = \exp(-\mu_{g,t})$	| $\exp(\mu_{g,t})$ |
+| [Gamma](https://mc-stan.org/docs/functions-reference/gamma-distribution.html)        |	$\alpha = \exp(\mu_{g,t})$, $\beta = \upsilon_{g,t}$ | $\exp(\mu_{g,t})/\upsilon_{g,t}$ |
+| [Log-logistic](https://en.wikipedia.org/wiki/Log-logistic_distribution) |	$\alpha = \exp(\mu_{g,t})$, $\beta = \upsilon_{g,t}$ | $\frac{\exp(\mu_{g,t})\,\pi/\upsilon_{g,t}}{\sin(\pi/\upsilon_{g,t})}$ |
 
 ## Discretisation and adjustment for maximum delay
 


### PR DESCRIPTION
This PR closes #278 

Some minor changes to the discrete delay distributions vignette - escaping functions to improve readibility and right-closing discretised bins.

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [x] I have read the [contribution guidelines](https://github.com/epinowcast/epinowcast/blob/main/CONTRIBUTING.md).
- [x] I have tested my changes locally.
- [x] I have updated the documentation if required.
- [x] My code follows the established coding standards.
- [x] I have added a news item linked to this PR.
- [x] I have updated the package development version by one increment in both `NEWS.md` and the `DESCRIPTION`.
- [x] I have reviewed CI checks for this PR and addressed them as far as I am able.

Seems to small to be worthy of a news item.