### PR TITLE
Issue 272: Make citation command print prettily

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,7 +30,7 @@ This release is in development and not yet ready for production use.
 ## Documentation
 
 - Updated the distributions vignette to match the updated handling of discretisation. See #288 by @seabbs and reviewed by @adrian-lison.
-- Updated the use of the `citation()` function in the README so that the command is shown to users and the output is treated like normal text. See #272 by @seabbs and reviewed by @pearsonca.
+- Updated the use of the `citation()` function in the README so that the command is shown to users and the output is treated like normal text. See #272 by @seabbs and self-reviewed.
 
 # epinowcast 0.2.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,7 @@ This release is in development and not yet ready for production use.
 ## Documentation
 
 - Updated the distributions vignette to match the updated handling of discretisation. See #288 by @seabbs and reviewed by @adrian-lison.
+- Updated the use of the `citation()` function in the README so that the command is shown to users and the output is treated like normal text. See #272 by @seabbs and reviewed by @pearsonca.
 
 # epinowcast 0.2.2
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -282,7 +282,7 @@ Here we see that the model is underestimating the incidence of hospitalisations 
 
 If you use `epinowcast` in your work, please consider citing it using the following,
 
-```{r}
+```{r, results = "asis"}
 citation("epinowcast")
 ```
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -282,7 +282,7 @@ Here we see that the model is underestimating the incidence of hospitalisations 
 
 If you use `epinowcast` in your work, please consider citing it using the following,
 
-```{r, echo = FALSE}
+```{r}
 citation("epinowcast")
 ```
 


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #272.

As discussed in #272 the citation command was not shown to users in the README. This PR fixes that. It also changes the output from `citation("epinowcast")` from a comment into normal text.

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [x] I have read the [contribution guidelines](https://github.com/epinowcast/epinowcast/blob/main/CONTRIBUTING.md).
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] My code follows the established coding standards.
- [x] I have added a news item linked to this PR.
- [x] I have updated the package development version by one increment in both `NEWS.md` and the `DESCRIPTION`.
- [x] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
