### PR TITLE
Issue 389: minimum supported R version 3.5 or 4.1

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -83,12 +83,12 @@ jobs:
         shell: Rscript {0}
 
       - uses: r-lib/actions/check-r-package@v2
-        if:  matrix.config.r != '3.5'
+        if:  matrix.config.r != '3.6'
         with:
           upload-snapshots: true
 
       - uses: r-lib/actions/check-r-package@v2
-        if:  matrix.config.r == '3.5'
+        if:  matrix.config.r == '3.6'
         with:
           args: 'c("--no-manual", "--as-cran", "--no-build-vignettes", "--ignore-vignettes")'
           upload-snapshots: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -33,6 +33,7 @@ jobs:
           - {os: windows-latest, r: 'release', rtools: '43'}
           - {os: ubuntu-latest,   r: 'release', rtools: ''}
           - {os: ubuntu-latest,   r: 'oldrel-1', rtools: ''}
+          - {os: ubuntu-latest,   r: '3.5', rtools: ''}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -82,5 +83,12 @@ jobs:
         shell: Rscript {0}
 
       - uses: r-lib/actions/check-r-package@v2
+        if:  ${{ matrix.config.r }} != '3.5'
         with:
+          upload-snapshots: true
+
+      - uses: r-lib/actions/check-r-package@v2
+        if:  ${{ matrix.config.r }} == '3.5'
+        with:
+          args: 'c("--no-manual", "--as-cran", "--no-build-vignettes", "--ignore-vignettes")'
           upload-snapshots: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -83,12 +83,12 @@ jobs:
         shell: Rscript {0}
 
       - uses: r-lib/actions/check-r-package@v2
-        if:  ${{ matrix.config.r }} != '3.5'
+        if:  matrix.config.r != '3.5'
         with:
           upload-snapshots: true
 
       - uses: r-lib/actions/check-r-package@v2
-        if:  ${{ matrix.config.r }} == '3.5'
+        if:  matrix.config.r == '3.5'
         with:
           args: 'c("--no-manual", "--as-cran", "--no-build-vignettes", "--ignore-vignettes")'
           upload-snapshots: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -33,7 +33,7 @@ jobs:
           - {os: windows-latest, r: 'release', rtools: '43'}
           - {os: ubuntu-latest,   r: 'release', rtools: ''}
           - {os: ubuntu-latest,   r: 'oldrel-1', rtools: ''}
-          - {os: ubuntu-latest,   r: '3.5', rtools: ''}
+          - {os: ubuntu-latest,   r: '3.6', rtools: ''}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -93,7 +93,7 @@ URL: https://package.epinowcast.org,
     https://github.com/epinowcast/epinowcast/
 BugReports: https://github.com/epinowcast/epinowcast/issues/
 Depends:
-    R (>= 3.5.0)
+    R (>= 3.6.0)
 Imports:
     cli,
     cmdstanr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,7 @@ This release is in development and not yet ready for production use.
 - Enabled compiling with multithreading by default as this was found to cause no deterioration in performance even with 1 thread per chain. The likelihood calculation is now no longer parallelised when `threads_per_chain = 1` which should offer a small performance improvement. See #366 by @sbfnk and reviewed by @seabbs.
 - Added a new action to check that the `cmdstan` model can be compiled and has the correct syntax. This runs on pull requests whenever stan code is changed, when code is merged onto `main` with altered stan code, and on a weekly schedule against the latest `main` branch. See #386 by @seabbs.
 - Switched to the `{cli}` package for all package messaging in order to have modern and pretty notifications. See #188 by @nikosbosse and @seabbs reviewed by @pearsonca.
+- Increased the minimum supported R version to >= R 3.6.0 from R 3.5.0 and ensured that existing function code and tests compiled with this dependency. Vignettes will continue to allow use of R >= 4.1.0 syntax (i.e., native pipe and lambda function syntax). See #389 by @medewitt and @seabbs and reviewed by @pearsonca.
 
 ## Model
 

--- a/R/model-modules.R
+++ b/R/model-modules.R
@@ -456,7 +456,7 @@ enw_expectation <- function(r = ~ 0 + (1 | day:.group), generation_time = 1,
           purrr::map2_dbl(
             as.vector(priors$expr_lelatent_int_p[1]),
             as.vector(priors$expr_lelatent_int_p[2]),
-            \(x, y) {
+            function(x, y) {
               rnorm(1, x, y * 0.1)
             }
           ),

--- a/R/utils.R
+++ b/R/utils.R
@@ -171,8 +171,7 @@ enw_example <- function(type = c(
 #' with error handling
 #'
 #' @param dates A vector-like input, which the function attempts
-#' to coerce via [data.table::as.IDate()]. Defaults to NULL (i.e. an
-#' empty vector).
+#' to coerce via [data.table::as.IDate()]. Defaults to NULL.
 #'
 #' @return An [IDate] vector.
 #'
@@ -197,7 +196,7 @@ enw_example <- function(type = c(
 #'     print(e)
 #'   }
 #' )
-coerce_date <- function(dates) {
+coerce_date <- function(dates = NULL) {
   if (is.null(dates)) {
     return(data.table::as.IDate(numeric()))
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -199,9 +199,8 @@ enw_example <- function(type = c(
 #' )
 coerce_date <- function(dates) {
   if (is.null(dates)) {
-    return(data.table::as.IDate(.Date(numeric())))
+    return(data.table::as.IDate(c()))
   }
-
   if (length(dates) == 0) {
     return(data.table::as.IDate(dates))
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -197,6 +197,10 @@ enw_example <- function(type = c(
 #'   }
 #' )
 coerce_date <- function(dates) {
+  if (is.null(dates)) {
+    return(data.table::as.IDate(.Date(numeric())))
+  }
+
   if (length(dates) == 0) {
     return(data.table::as.IDate(dates))
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -199,7 +199,7 @@ enw_example <- function(type = c(
 #' )
 coerce_date <- function(dates) {
   if (is.null(dates)) {
-    return(data.table::as.IDate(c()))
+    return(data.table::as.IDate(numeric()))
   }
   if (length(dates) == 0) {
     return(data.table::as.IDate(dates))

--- a/R/utils.R
+++ b/R/utils.R
@@ -171,7 +171,8 @@ enw_example <- function(type = c(
 #' with error handling
 #'
 #' @param dates A vector-like input, which the function attempts
-#' to coerce via [data.table::as.IDate()].
+#' to coerce via [data.table::as.IDate()]. Defaults to NULL (i.e. an
+#' empty vector).
 #'
 #' @return An [IDate] vector.
 #'
@@ -184,7 +185,7 @@ enw_example <- function(type = c(
 #'
 #' @export
 #' @importFrom data.table as.IDate
-#' @importFrom cli cli_abort
+#' @importFrom cli cli_abort cli_warn
 #' @family utils
 #' @examples
 #' # works

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ applied to any set of right-truncated time-series count data.
 ## Installation
 
 <details>
-
-<summary>Installing the package</summary>
+<summary>
+Installing the package
+</summary>
 
 You can install the latest released version using the normal `R`
 function, though you need to point to `r-universe` instead of CRAN:
@@ -51,7 +52,7 @@ install.packages(
 
 Alternatively, you can use the [`remotes`
 package](https://remotes.r-lib.org/) to install the development version
-from Github (warning\! this version may contain breaking changes and/or
+from Github (warning! this version may contain breaking changes and/or
 bugs):
 
 ``` r
@@ -75,10 +76,10 @@ if needed, e.g. if you want to try out a specific unreleased feature,
 but not the absolute latest developmental version.*
 
 </details>
-
 <details>
-
-<summary>Installing CmdStan</summary>
+<summary>
+Installing CmdStan
+</summary>
 
 If you wish to do model fitting and nowcasting, you will need to install
 [CmdStan](https://mc-stan.org/users/interfaces/cmdstan), which also
@@ -105,10 +106,10 @@ need to install a past version of CmdStan, which you can do with the
 `version` argument.*
 
 </details>
-
 <details>
-
-<summary>Alternative: Docker</summary>
+<summary>
+Alternative: Docker
+</summary>
 
 We also provide a [Docker](https://www.docker.com/get-started/) image
 with [`epinowcast` and all dependencies
@@ -122,12 +123,13 @@ dependencies.
 
 As you use the package, the documentation available via `?enw_` should
 be your first stop for troubleshooting. We also provide a range of other
-documentation, case studies, and community spaces to ask (and answer\!)
+documentation, case studies, and community spaces to ask (and answer!)
 questions:
 
 <details>
-
-<summary>Package Website</summary>
+<summary>
+Package Website
+</summary>
 
 The [`epinowcast` website](https://package.epinowcast.org/) includes a
 function reference, model outline, and case studies using the package.
@@ -136,10 +138,10 @@ documentation for [the latest development
 version](https://package.epinowcast.org/dev/).
 
 </details>
-
 <details>
-
-<summary>R Vignettes</summary>
+<summary>
+R Vignettes
+</summary>
 
 We have created [package
 vignettes](https://package.epinowcast.org/articles) to help you [get
@@ -149,10 +151,10 @@ to [highlight other features with case
 studies](https://package.epinowcast.org/articles/germany-age-stratified-nowcasting.html).
 
 </details>
-
 <details>
-
-<summary>Organisation Website</summary>
+<summary>
+Organisation Website
+</summary>
 
 Our [organisation website](https://www.epinowcast.org/) includes links
 to other resources, [guest posts](https://www.epinowcast.org/blog.html),
@@ -160,10 +162,10 @@ and [seminar schedule](https://www.epinowcast.org/seminars.html) for
 both upcoming and past recordings.
 
 </details>
-
 <details>
-
-<summary>Community Forum</summary>
+<summary>
+Community Forum
+</summary>
 
 Our [community forum](https://community.epinowcast.org/) has areas for
 [question and answer](https://community.epinowcast.org/c/interface/15)
@@ -173,10 +175,10 @@ you are generally interested in real-time analysis of infectious
 disease, you may find this useful even if do not use `epinowcast`.
 
 </details>
-
 <details>
-
-<summary>Package Analysis Scripts</summary>
+<summary>
+Package Analysis Scripts
+</summary>
 
 In addition to the vignettes, the package also comes with [example
 analyses](https://github.com/epinowcast/epinowcast/tree/main/inst/examples).
@@ -194,7 +196,7 @@ list.files(
 
 ## Contributing
 
-We welcome contributions and new contributors\! We particularly
+We welcome contributions and new contributors! We particularly
 appreciate help on [identifying and identified
 issues](https://github.com/epinowcast/epinowcast/issues). Please check
 and add to the issues, and/or add a [pull
@@ -204,9 +206,9 @@ guide](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md)
 for more information.
 
 If you need a different underlying model for your work: `epinowcast`
-lets you pass your own models\! If you do try new model
-parameterisations that expand the overall flexibility or improve the
-defaults, please let us know either here or on the [community
+lets you pass your own models! If you do try new model parameterisations
+that expand the overall flexibility or improve the defaults, please let
+us know either here or on the [community
 forum](https://community.epinowcast.org/). We always like to hear about
 new use-cases, whether or not they are directed at the core `epinowcast`
 applications.

--- a/man/coerce_date.Rd
+++ b/man/coerce_date.Rd
@@ -8,7 +8,8 @@ coerce_date(dates)
 }
 \arguments{
 \item{dates}{A vector-like input, which the function attempts
-to coerce via \code{\link[data.table:IDateTime]{data.table::as.IDate()}}.}
+to coerce via \code{\link[data.table:IDateTime]{data.table::as.IDate()}}. Defaults to NULL (i.e. an
+empty vector).}
 }
 \value{
 An \link{IDate} vector.

--- a/man/coerce_date.Rd
+++ b/man/coerce_date.Rd
@@ -4,12 +4,11 @@
 \alias{coerce_date}
 \title{Coerce Dates}
 \usage{
-coerce_date(dates)
+coerce_date(dates = NULL)
 }
 \arguments{
 \item{dates}{A vector-like input, which the function attempts
-to coerce via \code{\link[data.table:IDateTime]{data.table::as.IDate()}}. Defaults to NULL (i.e. an
-empty vector).}
+to coerce via \code{\link[data.table:IDateTime]{data.table::as.IDate()}}. Defaults to NULL.}
 }
 \value{
 An \link{IDate} vector.

--- a/tests/testthat/helper-expectations.R
+++ b/tests/testthat/helper-expectations.R
@@ -26,9 +26,11 @@ expect_diff_sum_abs_lt <- function(x, y, diff) {
 }
 
 expect_zero_length_or_not <- function(vars, vars_list) {
-  purrr::walk(vars_list[vars], testthat::expect_length, 0)
+  purrr::walk(vars_list[vars], testthat::expect_length, n = 0)
   purrr::walk(
-    vars_list[!names(vars_list) %in% vars], ~ testthat::expect_gt(length(.x), 0)
+    vars_list[!names(vars_list) %in% vars], function(x) {
+      testthat::expect_gt(length(x), 0)
+    }
   )
 }
 

--- a/tests/testthat/helper-functions.R
+++ b/tests/testthat/helper-functions.R
@@ -38,3 +38,24 @@ dt_copies <- function(...) {
 dt_compare_all <- function(ref_copies, ...) {
   all(mapply(function(l, r) all(l == r), ref_copies, list(...)))
 }
+
+check_r_version <- function(min_major = 4, min_minor = 0){
+
+  current_version <- as.numeric(
+    paste0(
+      R.version[["major"]],
+      ".",
+      gsub("(\\d+)\\..*", "\\1", R.version[["minor"]])
+    )
+  )
+
+  target_min_version <- as.numeric(
+    paste0(min_major, ".",min_minor)
+  )
+
+  if (current_version >= target_min_version) {
+    return(TRUE)
+  } else {
+    return (FALSE)
+  }
+}

--- a/tests/testthat/helper-functions.R
+++ b/tests/testthat/helper-functions.R
@@ -39,7 +39,7 @@ dt_compare_all <- function(ref_copies, ...) {
   all(mapply(function(l, r) all(l == r), ref_copies, list(...)))
 }
 
-check_r_version <- function(min_major = 4, min_minor = 0){
+check_r_version <- function(min_major = 4, min_minor = 0) {
 
   current_version <- as.numeric(
     paste0(
@@ -50,12 +50,12 @@ check_r_version <- function(min_major = 4, min_minor = 0){
   )
 
   target_min_version <- as.numeric(
-    paste0(min_major, ".",min_minor)
+    paste0(min_major, ".", min_minor)
   )
 
   if (current_version >= target_min_version) {
     return(TRUE)
   } else {
-    return (FALSE)
+    return(FALSE)
   }
 }

--- a/tests/testthat/helper-state.R
+++ b/tests/testthat/helper-state.R
@@ -11,8 +11,8 @@ testthat::set_state_inspector(function() {
     connections = getAllConnections(),
     cwd         = getwd(),
     envvars     = Sys.getenv(),
-    handlers    = if (check_r_version(4, 0 )) {
-      globalCallingHandlers()
+    handlers    = if (getRversion() >= "4.0.0") {
+        globalCallingHandlers()
       } else {
         Sys.getenv("error")
       },

--- a/tests/testthat/helper-state.R
+++ b/tests/testthat/helper-state.R
@@ -3,13 +3,19 @@
 # If global settings need to be modified, they should be restored to their
 # original values on exit. This can be achieved with the `on.exit()` base
 # function, or more conveniently with the `withr` package.
+# Note that `globalCallingHandlers` is only available on version of R >= 4.0
+
 testthat::set_state_inspector(function() {
   list(
     attached    = search(),
     connections = getAllConnections(),
     cwd         = getwd(),
     envvars     = Sys.getenv(),
-    handlers    = globalCallingHandlers(),
+    handlers    = if (check_r_version(4, 0 )) {
+      globalCallingHandlers()
+      } else {
+        Sys.getenv("error")
+      },
     libpaths    = .libPaths(),
     locale      = Sys.getlocale(),
     options     = options(),

--- a/tests/testthat/test-coerce_date.R
+++ b/tests/testthat/test-coerce_date.R
@@ -9,14 +9,12 @@ test_that("coerce_date works for non-garbage in", {
   expect_error(
     coerce_date(refresult), NA
   )
-  expect_error(
-    coerce_date(NULL), NA
-  )
-  expect_error(
-    coerce_date(NULL), NA
-  )
   expect_identical(
     coerce_date(NULL),
+    data.table::as.IDate(.Date(numeric()))
+  )
+  expect_identical(
+    coerce_date(integer()),
     data.table::as.IDate(.Date(numeric()))
   )
   coerced <- coerce_date(nongarbage)

--- a/tests/testthat/test-coerce_date.R
+++ b/tests/testthat/test-coerce_date.R
@@ -12,6 +12,13 @@ test_that("coerce_date works for non-garbage in", {
   expect_error(
     coerce_date(NULL), NA
   )
+  expect_error(
+    coerce_date(NULL), NA
+  )
+  expect_equal(
+    coerce_date(NULL), 
+    data.table::as.IDate(.Date(numeric()))
+  )
   coerced <- coerce_date(nongarbage)
   expect_identical(coerced, refresult)
   expect_identical(class(coerced), class(refresult)) # nolint: expect_s3_class

--- a/tests/testthat/test-coerce_date.R
+++ b/tests/testthat/test-coerce_date.R
@@ -15,8 +15,8 @@ test_that("coerce_date works for non-garbage in", {
   expect_error(
     coerce_date(NULL), NA
   )
-  expect_equal(
-    coerce_date(NULL), 
+  expect_identical(
+    coerce_date(NULL),
     data.table::as.IDate(.Date(numeric()))
   )
   coerced <- coerce_date(nongarbage)

--- a/tests/testthat/test-enw_preprocess_data.R
+++ b/tests/testthat/test-enw_preprocess_data.R
@@ -57,13 +57,14 @@ test_that("enw_preprocess_data() handles groups as expected", {
 })
 
 test_that(
-  "enw_preprocess_data() can handle a non-default timestep as expected",
-  {
-    weekly_nat_germany_hosp <- nat_germany_hosp |>
-      enw_aggregate_cumulative(timestep = "week")
+  "enw_preprocess_data() can handle a non-default timestep as expected", {
+    weekly_nat_germany_hosp <- enw_aggregate_cumulative(
+      nat_germany_hosp, timestep = "week"
+    )
 
-    weekly_nat_germany_hosp <- weekly_nat_germany_hosp |>
-      enw_filter_reference_dates(earliest_date = "2021-05-10")
+    weekly_nat_germany_hosp <- enw_filter_reference_dates(
+      weekly_nat_germany_hosp, earliest_date = "2021-05-10"
+    )
 
     weekly_pobs <- enw_preprocess_data(
       weekly_nat_germany_hosp,

--- a/tests/testthat/test-enw_reference.R
+++ b/tests/testthat/test-enw_reference.R
@@ -1,15 +1,17 @@
 # Use example data
 pobs <- enw_example("preprocessed")
 
+pobs_intermediate <- enw_filter_reference_dates(
+  pobs$obs[[1]][, ".group" := NULL], latest_date = "2021-07-20"
+)
+
+pobs_intermediate <- enw_filter_report_dates(
+  pobs_intermediate,
+  latest_date = "2021-07-20"
+)
+
 pobs_filt <- enw_preprocess_data(
-  pobs$obs[[1]][, ".group" := NULL] |>
-    enw_filter_reference_dates(
-      latest_date = "2021-07-20"
-    ) |>
-    enw_filter_report_dates(
-      latest_date = "2021-07-20"
-    ),
-  max_delay = 2
+  pobs_intermediate, max_delay = 2
 )
 
 test_that("enw_reference requires at least one of a parametric or a

--- a/tests/testthat/test-epinowcast.R
+++ b/tests/testthat/test-epinowcast.R
@@ -12,9 +12,9 @@ if (not_on_cran() && on_ci()) {
 }
 
 # A function to filter data used in test suite
-run_window_filter <- function(x) {
-    obs <- enw_filter_report_dates(x, remove_days = 10)
-    obs <- enw_filter_reference_dates(obs, include_days = 10)
+run_window_filter <- function(x, filter_report_remove = 10, filter_reference_include = 10) {
+    obs <- enw_filter_report_dates(x, remove_days = filter_report_remove)
+    obs <- enw_filter_reference_dates(obs, include_days = filter_reference_include)
     return(obs)
 }
 
@@ -100,7 +100,7 @@ test_that("epinowcast() runs with within-chain parallelisation", {
   skip_on_cran()
   skip_on_local()
   obs <- run_window_filter(
-    germany_covid19_hosp[age_group %in% "00+"][location %in% "DE"]
+    germany_covid19_hosp[age_group == "00+"][location == "DE"]
   )
   pobs <- enw_preprocess_data(obs, max_delay = 5)
   nowcast <- suppressMessages(

--- a/tests/testthat/test-epinowcast.R
+++ b/tests/testthat/test-epinowcast.R
@@ -12,7 +12,7 @@ if (not_on_cran() && on_ci()) {
 }
 
 # A function to filter data used in test suite
-run_window_filter <- function(x){
+run_window_filter <- function(x) {
     obs <- enw_filter_report_dates(x, remove_days = 10)
     obs <- enw_filter_reference_dates(obs, include_days = 10)
     return(obs)
@@ -158,7 +158,7 @@ test_that("epinowcast() can fit a simple reporting model where the max delay is
         pobs$obs[[1]][, .group := NULL],
         include_days = 20
       ),
-    max_delay = 30
+      max_delay = 30
     )
   )
 

--- a/tests/testthat/test-epinowcast.R
+++ b/tests/testthat/test-epinowcast.R
@@ -12,10 +12,14 @@ if (not_on_cran() && on_ci()) {
 }
 
 # A function to filter data used in test suite
-run_window_filter <- function(x, filter_report_remove = 10, filter_reference_include = 10) {
-    obs <- enw_filter_report_dates(x, remove_days = filter_report_remove)
-    obs <- enw_filter_reference_dates(obs, include_days = filter_reference_include)
-    return(obs)
+run_window_filter <- function(
+  x, filter_report_remove = 10, filter_reference_include = 10
+) {
+  obs <- enw_filter_report_dates(x, remove_days = filter_report_remove)
+  obs <- enw_filter_reference_dates(
+    obs, include_days = filter_reference_include
+  )
+  return(obs)
 }
 
 test_that("epinowcast() preprocesses data and model modules as expected", {
@@ -39,7 +43,9 @@ test_that("epinowcast() runs using default arguments only", {
   skip_on_cran()
   skip_on_local()
 
-  obs <- run_window_filter(germany_covid19_hosp[age_group == "00+"][location == "DE"])  
+  obs <- run_window_filter(
+    germany_covid19_hosp[age_group == "00+"][location == "DE"]
+  )
   pobs <- enw_preprocess_data(obs, max_delay = 5)
   nowcast <- suppressMessages(epinowcast(pobs))
   expect_identical(


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #389  (maybe...).

Replaces post R4.1.0 anonymous function syntax (`\(x)`) and native pipe (`|>`) from the source and test files.
Does not remove or notify the users that R >= 4.1.0 is necessary for running or rebuilding the vignettes.
This will at least guarantee that the package will build and test on platforms with R >= 3.5.

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [x] I have read the [contribution guidelines](https://github.com/epinowcast/epinowcast/blob/main/CONTRIBUTING.md).
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] My code follows the established coding standards.
- [x] I have added a news item linked to this PR.
- [x] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
