### PR TITLE
Issue 415: Change all vignette authorship to be epinowcast team vs individuals

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -62,6 +62,7 @@ This release is in development and not yet ready for production use.
 - Removed the reference in the pull request template to updating the development version as this has been found to cause issues when multiple pull requests are open at once. See #391 by @seabbs and reviewed by @Bisaloo.
 - Added a note to the Getting Started vignette to clarify usability with alternatives to data.table. See #406 by @kathsherratt and reviewed by @seabbs.
 - Added a new vignette to provide users with a configuration and troubleshooting guide for Stan while working with `epinowcast`. See #405 by @medewitt and reviewed by @seabbs, @zsusswein, and @pearsonca.
+- Removed named individuals from vignettes and moved to a team authorship. See # by @seabbs and reviewed by .
 
 ## Depreciations
 

--- a/vignettes/distributions.Rmd
+++ b/vignettes/distributions.Rmd
@@ -1,7 +1,7 @@
 ---
 title: Discretised distributions
 description: "Distributions and their discretisation in epinowcast"
-author: Sam Abbott, Adrian Lison, Felix Günther
+author: Epinowcast Team
 output: rmarkdown::html_document
 bibliography: library.bib
 csl: https://raw.githubusercontent.com/citation-style-language/styles/master/apa-numeric-superscript-brackets.csl

--- a/vignettes/germany-age-stratified-nowcasting.Rmd
+++ b/vignettes/germany-age-stratified-nowcasting.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Hierarchical nowcasting of age stratified COVID-19 hospitalisations in Germany"
 description: "A case study exploring hierarchical models of varying complexity to jointly nowcast age stratified COVID-19 hospitalisations in Germany."
-author: Sam Abbott
+author: Epinowcast Team
 opengraph:
   image: 
     src: figures/germany-age-stratified-nowcasting-performance-1.png

--- a/vignettes/germany-age-stratified-nowcasting.Rmd.orig
+++ b/vignettes/germany-age-stratified-nowcasting.Rmd.orig
@@ -1,7 +1,7 @@
 ---
 title: "Hierarchical nowcasting of age stratified COVID-19 hospitalisations in Germany"
 description: "A case study exploring hierarchical models of varying complexity to jointly nowcast age stratified COVID-19 hospitalisations in Germany."
-author: Sam Abbott
+author: Epinowcast Team
 opengraph:
   image: 
     src: figures/germany-age-stratified-nowcasting-performance-1.png

--- a/vignettes/model.Rmd
+++ b/vignettes/model.Rmd
@@ -1,7 +1,7 @@
 ---
 title: Model definition and implementation
 description: "Model formulation and implementation details"
-author: Sam Abbott, Adrian Lison, Felix Günther, Sebastian Funk
+author: Epinowcast Team
 output: 
   bookdown::html_vignette2:
     fig_caption: yes

--- a/vignettes/single-timeseries-rt-estimation.Rmd
+++ b/vignettes/single-timeseries-rt-estimation.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Estimating the effective reproduction number in real-time for a single timeseries with reporting delays"
 description: "A walk through of a simple approach to jointly estimating the effective reproduction number over time and the delay from a positive test to this test being reported."
-author: Sam Abbott
+author: Epinowcast Team
 opengraph:
   image: 
     src: figures/single-timeseries-rt-estimation-plot-germany-rt-1.png

--- a/vignettes/single-timeseries-rt-estimation.Rmd.orig
+++ b/vignettes/single-timeseries-rt-estimation.Rmd.orig
@@ -1,7 +1,7 @@
 ---
 title: "Estimating the effective reproduction number in real-time for a single timeseries with reporting delays"
 description: "A walk through of a simple approach to jointly estimating the effective reproduction number over time and the delay from a positive test to this test being reported."
-author: Sam Abbott
+author: Epinowcast Team
 opengraph:
   image: 
     src: figures/single-timeseries-rt-estimation-plot-germany-rt-1.png

--- a/vignettes/stan-help.Rmd
+++ b/vignettes/stan-help.Rmd
@@ -1,7 +1,7 @@
 ---
 title: Resources to help with model fitting using Stan
 description: "How to address issues you may encounter with Stan"
-author: Michael E. DeWitt, Sam Abbott, Zachary Susswein, Carl A. B. Pearson
+author: Epinowcast Team
 output: 
   bookdown::html_vignette2:
     fig_caption: yes


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #415. It drops individuals from all vignettes and instead includes a team authorship. As `pgdown` automatically includes a link to the `vignette` source I have not added a manual link out to this as discussed in #415. 

Could reviewers please suggest their usernames in the news item as reviewers. Note that all tagged reviewers don't need to review this as we have already discussed and agreed these changes in #415 so tagging is just for visibility.

[Describe the changes that you made in this pull request.]

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [x] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] My code follows the established coding standards.
- [x] I have added a news item linked to this PR.
- [x] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
