### PR TITLE
Issue 302: Improve commenting of maximum delay in Stan code

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -67,7 +67,8 @@ This release is in development and not yet ready for production use.
 - Removed the reference in the pull request template to updating the development version as this has been found to cause issues when multiple pull requests are open at once. See #391 by @seabbs and reviewed by @Bisaloo.
 - Added a note to the Getting Started vignette to clarify usability with alternatives to data.table. See #406 by @kathsherratt and reviewed by @seabbs.
 - Added a new vignette to provide users with a configuration and troubleshooting guide for Stan while working with `epinowcast`. See #405 by @medewitt and reviewed by @seabbs, @zsusswein, and @pearsonca.
-- Removed named individuals from vignettes and moved to a team authorship. See # by @seabbs and reviewed by .
+- Removed named individuals from vignettes and moved to team authorship. See # by @seabbs and self-reviewed.
+- Improved documentation of the maximum delay in the stan code. See #425 by @adrianlison and reviewed by @seabbs.
 
 ## Depreciations
 

--- a/inst/stan/functions/discretised_logit_hazard.stan
+++ b/inst/stan/functions/discretised_logit_hazard.stan
@@ -28,7 +28,7 @@ real loglogistic_lcdf (real y, real alpha, real beta) {
  *
  * @param sigma Scale parameter for the distribution.
  *
- * @param u Upper bound of the discretized LCDF.
+ * @param u Upper bound of the discretised LCDF.
  *
  * @param dist Integer flag for distribution type (1: exponential, 2: lognormal,
  * 3: gamma, 4: log-logistic).

--- a/inst/stan/functions/discretised_logit_hazard.stan
+++ b/inst/stan/functions/discretised_logit_hazard.stan
@@ -18,9 +18,9 @@ real loglogistic_lcdf (real y, real alpha, real beta) {
 }
 
 /**
- * Compute vectorised LCDF for various distributions
+ * Compute the discretised LCDF for various distributions
  * 
- * Computes the LCDF for values from 1 to n for a selected parametric
+ * Computes the LCDF at integer points from 1 to u for a selected parametric
  * distribution. Supports exponential, lognormal, gamma, and log-logistic
  * distributions.
  * 
@@ -28,7 +28,7 @@ real loglogistic_lcdf (real y, real alpha, real beta) {
  *
  * @param sigma Scale parameter for the distribution.
  *
- * @param n Upper limit for computing LCDF values.
+ * @param u Upper bound of the discretized LCDF.
  *
  * @param dist Integer flag for distribution type (1: exponential, 2: lognormal,
  * 3: gamma, 4: log-logistic).
@@ -37,25 +37,25 @@ real loglogistic_lcdf (real y, real alpha, real beta) {
  * 
  * @note Uses `loglogistic_lcdf` for the log-logistic distribution.
  */
-vector lcdf_discretised(real mu, real sigma, int n, int dist) {
-  vector[n] integer_lcdf;
+vector lcdf_discretised(real mu, real sigma, int u, int dist) {
+  vector[u] integer_lcdf;
   if (dist == 1) {
     real emu = exp(-mu);
-    for (i in 1:n) {
+    for (i in 1:u) {
       integer_lcdf[i] = exponential_lcdf(i | emu);
     }
   } else if (dist == 2) {
-    for (i in 1:n) {
+    for (i in 1:u) {
       integer_lcdf[i] = lognormal_lcdf(i | mu, sigma);
     }
   } else if (dist == 3) {
     real emu = exp(mu);
-    for (i in 1:n) {
+    for (i in 1:u) {
       integer_lcdf[i] = gamma_lcdf(i | emu, sigma);
     }
   } else if (dist == 4) {
     real emu = exp(mu);
-    for (i in 1:n) {
+    for (i in 1:u) {
       integer_lcdf[i] = loglogistic_lcdf(i | emu, sigma);
     }
   } else {
@@ -65,46 +65,51 @@ vector lcdf_discretised(real mu, real sigma, int n, int dist) {
 }
 
 /**
- * Normalise LCDF values under double censoring
+ * Normalise a discretised LCDF under double censoring
  * 
- * Adjusts LCDF evaluations for probability mass beyond the maximum observed 
- * value, assuming double censoring and a uniform interval approximation. 
- * Different strategies are applied based on `max_strat`.
+ * Adjusts LCDF values for the probability mass beyond the upper bound of the 
+ * discretised LCDF, assuming double censoring and a uniform interval 
+ * approximation. Different strategies are applied depending on `max_strat`.
  * 
  * @param lcdf Vector of LCDF values to be adjusted.
  *
- * @param n Number of LCDF values.
+ * @param u Upper bound of the discretized LCDF.
  *
- * @param max_strat Strategy for handling probability mass beyond the maximum.
+ * @param max_strat Strategy for handling probability mass beyond upper bound.
  * 
  * @return Vector of adjusted LCDF values.
  * 
  * @note Used on the output of `lcdf_discretised`.
  */
-vector normalise_lcdf_as_uniform_double_censored(vector lcdf, int n,
+vector normalise_lcdf_as_uniform_double_censored(vector lcdf, int u,
   int max_strat) {
-  vector[n] adjusted_lcdf;
+  vector[u] adjusted_lcdf;
   if (max_strat == 0) {
-    // ignore (i.e sum of probability does not add to 1)
+    // ignore (i.e. sum of probabilities does not add to 1)
     // NOTE: This cannot be used when using lcdf_to_logit_hazard as
     // it will return the same result as using strategy 2.
     adjusted_lcdf = lcdf;
   } else if (max_strat == 1) {
-    // add to maximum value: cdf_n = 1
+    // add to upper bound: cdf_u = 1 (i.e. lcdf_u = 0)
     adjusted_lcdf = lcdf;
-    adjusted_lcdf[n] = 0;
+    adjusted_lcdf[u] = 0;
     // normalise to account for double censoring
     adjusted_lcdf = adjusted_lcdf - log(2);
   } else if (max_strat == 2) {
-    // normalize: cdf = cdf / (cdf[n] + cdf[n-1])
-    // both n and n-1 are in the denominator to account for 2 day width of the
-    // interval period
-    // If n were infinite this would be equivalent to dividing by 2.
-    if (n == 1) {
+    // normalize: cdf = cdf / (cdf[u] + cdf[u-1])
+    // both u and u-1 are in the denominator to account for the 2 day width of
+    // the (overlapping) intervals from the uniform interval approximation:
+    // For a delay d, the interval is [d-1, d+1], e.g. the interval for delay 0 
+    // goes from -1 to 1, and the interval for delay 1 goes from 0 to 2 in the 
+    // LCDF, respectively. For a maximum delay of D days, we therefore evaluate 
+    // the LCDF up to the integer u = D+1. The total mass of this LCDF is thus:
+    // sum_{d=0}^D (F_{d+1} - F_{d-1}) = sum_{i=1}^u (F_{i} - F_{i-2}) = F_{u} + F_{u-1}
+    // If u were infinite this would be equivalent to dividing by 2.
+    if (u == 1) {
       adjusted_lcdf = lcdf - lcdf[1];
     }
-    if (n > 1) {
-      adjusted_lcdf = lcdf - log_sum_exp(lcdf[n], lcdf[n-1]);
+    if (u > 1) {
+      adjusted_lcdf = lcdf - log_sum_exp(lcdf[u], lcdf[u-1]);
     }
   } else {
     reject("Unknown strategy to handle probability mass beyond the maximum value.");
@@ -113,48 +118,56 @@ vector normalise_lcdf_as_uniform_double_censored(vector lcdf, int n,
 }
 
 /**
- * Compute LPMF from LCDF under double censoring
+ * Compute LPMF from discretised LCDF under double censoring
  * 
  * Converts LCDF values to log-scale probability mass function (LPMF) assuming 
- * double censoring and a uniform interval approximation, suitable for 
- * discretised data from 0 to n.
+ * double censoring and a uniform interval approximation. Suitable for 
+ * discretised LCDFs evaluated at integers 1 to u.
  * 
  * @param lcdf Vector of LCDF values.
  *
- * @param n Number of discrete points.
+ * @param u Upper bound of the discretized LCDF / LPMF.
  * 
  * @return Vector of log-scale PMF values.
  * 
+ * @note While the elements of the LCDF vector correspond to delays 1 to u, the
+ * elements of the PMF correspond to delays 0:(u-1). Hence, log(p_0) = lpmf[1].
+ *
  * @note Processes output of `normalise_lcdf_as_uniform_double_censored`.
  */
-vector lcdf_to_uniform_double_censored_log_prob(vector lcdf, int n) {
-  vector[n] lpmf; 
+vector lcdf_to_uniform_double_censored_log_prob(vector lcdf, int u) {
+  vector[u] lpmf; 
   // p_0 = cdf_1 - cdf_0
   lpmf[1] = lcdf[1];
-  if (n > 1) {
+  if (u > 1) {
     // p_1 = cdf_2 - cdf_0
     lpmf[2] = lcdf[2];
-    if (n > 2) {
-      // p_n = cdf_n+1 - cdf_n-1
-      lpmf[3:n] = log_diff_exp(lcdf[3:n], lcdf[1:(n-2)]);
+    if (u > 2) {
+      // p_u = cdf_u+1 - cdf_u-1
+      lpmf[3:u] = log_diff_exp(lcdf[3:u], lcdf[1:(u-2)]);
     }
   }
   return(lpmf);
 }
 
 /**
- * Compute logit hazards from log probabilities and LCDF
+ * Compute logit hazards from log probabilities.
  * 
- * Derives logit hazards from log probabilities and LCDF values, assuming 
- * double censoring and a uniform interval approximation for discretised data.
+ * Derives logit hazards from log probabilities of a delay LPMF, assuming 
+ * double censoring and a uniform interval approximation for discretised delays.
  * 
- * @param lprob Vector of log probabilities.
+ * @param lprob Vector of log probabilities from the LPMF.
  *
- * @param lcdf Vector of LCDF values.
+ * @param lcdf Vector of corresponding LCDF values for the LMPF. This could also
+ * be computed from lprob, but by re-using the precomputed LCDF from elsewhere 
+ * we reduce overall computation.
  *
- * @param n Number of discrete points.
+ * @param u Upper bound of discretized LCDF.
  * 
  * @return Vector of logit hazards.
+ *
+* @note While the elements of the LCDF vector correspond to delays 1 to u, the
+ * elements of the PMF correspond to delays 0:(u-1). Hence, log(h_0) = lhaz[1].
  * 
  * @note Processes output of `lcdf_to_uniform_double_censored_log_prob`
  * and `normalise_lcdf_as_uniform_double_censored
@@ -180,9 +193,9 @@ vector lcdf_to_uniform_double_censored_log_prob(vector lcdf, int n) {
  * @f]
  */
 vector lprob_to_uniform_double_censored_log_hazard(vector lprob, vector lcdf,
-   int n) {
-  vector[n] lhaz;
-  // h_0 = cdf_1
+   int u) {
+  vector[u] lhaz;
+  // h_0 = F_1
   lhaz[1] = lcdf[1];
   // h_n = p_n / (1 - sum^{n-1}_{d=0} p_d)
   // h_n = (cdf_n+1 - cdf_n-1) / (1 - sum^{n-1}_{d=0} cdf_d+1 - cdf_d-1)
@@ -195,8 +208,8 @@ vector lprob_to_uniform_double_censored_log_hazard(vector lprob, vector lcdf,
     // cccdf_n = 1 - cdf_n
     lccdf = log1m_exp(lcdf[1:(n-2)]);
     lhaz[2] = lprob[2] - lccdf[1];
-    if (n > 2) {
-      lhaz[3:(n-1)] = lprob[3:(n-1)] - log_diff_exp(lccdf[2:(n-2)], lcdf[1:(n-3)]);
+    if (u > 2) {
+      lhaz[3:(u-1)] = lprob[3:(u-1)] - log_diff_exp(lccdf[2:(u-2)], lcdf[1:(u-3)]);
     }
   }
   return(lhaz);
@@ -227,20 +240,21 @@ vector log_hazard_to_logit_hazard(vector lhaz, int n) {
 }
 
 /**
- * Calculate discretised logit hazard or log probability
+ * Calculate logit hazard or log probability for discretised delay distribution
  * 
- * Computes discretised logit hazards or log probabilities for a specified 
- * distribution up to a maximum observed delay. It employs various 
+ * Computes logit hazards or log probabilities for a specified discretised
+ * parametric distribution up to a maximum possible delay. Employs various 
  * normalisation strategies and assumes that delays are double-censored and 
  * that the interval width is approximately uniformly distributed.
  * 
- * @param mu Location parameter of the distribution.
+ * @param mu Location parameter of the parametric distribution.
  *
- * @param sigma Scale parameter of the distribution.
+ * @param sigma Scale parameter of the parametric distribution.
  *
- * @param n Number of discrete points.
+ * @param dmax Maximum possible delay. The parametric distribution will be 
+ * truncated at dmax.
  *
- * @param dist Distribution type indicator (e.g., exponential, lognormal).
+ * @param dist Distribution type indicator (e.g., exponential, lognormal, ...).
  *
  * @param max_strat Strategy for normalising LCDF values (e.g., handling 
  * probability mass beyond the maximum observed value).
@@ -248,7 +262,8 @@ vector log_hazard_to_logit_hazard(vector lhaz, int n) {
  * @param ref_as_p Flag indicating whether to return log probabilities directly 
  * (1) or to convert to logit hazards (0).
  * 
- * @return A vector of discretised logit hazards or log probabilities.
+ * @return A vector of logit hazards or log probabilities of the discretised 
+ * distribution, representing discrete delays from 0 to (dmax-1).
  * 
  * @note This function integrates several steps:
  *       1. Generates LCDF values using `lcdf_discretised`.
@@ -256,7 +271,7 @@ vector log_hazard_to_logit_hazard(vector lhaz, int n) {
  *          `normalise_lcdf_as_uniform_double_censored`.
  *       3. Converts LCDF to log probabilities using
  *          `lcdf_to_uniform_double_censored_log_prob`.
- *       4. If `ref_as_p` is 0, it further processes these probabilities into 
+ *       4. If `ref_as_p` is 0, further processes these probabilities into 
  *          logit hazards using `lprob_to_uniform_double_censored_log_hazard`
  *          and `log_hazard_to_logit_hazard`.
  * 

--- a/inst/stan/functions/discretised_logit_hazard.stan
+++ b/inst/stan/functions/discretised_logit_hazard.stan
@@ -73,7 +73,7 @@ vector lcdf_discretised(real mu, real sigma, int u, int dist) {
  * 
  * @param lcdf Vector of LCDF values to be adjusted.
  *
- * @param u Upper bound of the discretized LCDF.
+ * @param u Upper bound of the discretised LCDF.
  *
  * @param max_strat Strategy for handling probability mass beyond upper bound.
  * 

--- a/inst/stan/functions/discretised_logit_hazard.stan
+++ b/inst/stan/functions/discretised_logit_hazard.stan
@@ -126,7 +126,7 @@ vector normalise_lcdf_as_uniform_double_censored(vector lcdf, int u,
  * 
  * @param lcdf Vector of LCDF values.
  *
- * @param u Upper bound of the discretized LCDF / LPMF.
+ * @param u Upper bound of the discretised LCDF / LPMF.
  * 
  * @return Vector of log-scale PMF values.
  * 

--- a/inst/stan/functions/discretised_logit_hazard.stan
+++ b/inst/stan/functions/discretised_logit_hazard.stan
@@ -162,7 +162,7 @@ vector lcdf_to_uniform_double_censored_log_prob(vector lcdf, int u) {
  * be computed from lprob, but by re-using the precomputed LCDF from elsewhere 
  * we reduce overall computation.
  *
- * @param u Upper bound of discretized LCDF.
+ * @param u Upper bound of discretised LCDF.
  * 
  * @return Vector of logit hazards.
  *

--- a/inst/stan/functions/discretised_logit_hazard.stan
+++ b/inst/stan/functions/discretised_logit_hazard.stan
@@ -37,7 +37,7 @@ real loglogistic_lcdf (real y, real alpha, real beta) {
  * 
  * @note Uses `loglogistic_lcdf` for the log-logistic distribution.
  */
-vector lcdf_vectorised(real mu, real sigma, int n, int dist) {
+vector lcdf_discretised(real mu, real sigma, int n, int dist) {
   vector[n] integer_lcdf;
   if (dist == 1) {
     real emu = exp(-mu);
@@ -79,7 +79,7 @@ vector lcdf_vectorised(real mu, real sigma, int n, int dist) {
  * 
  * @return Vector of adjusted LCDF values.
  * 
- * @note Used on the output of `lcdf_vectorised`.
+ * @note Used on the output of `lcdf_discretised`.
  */
 vector normalise_lcdf_as_uniform_double_censored(vector lcdf, int n,
   int max_strat) {
@@ -251,7 +251,7 @@ vector log_hazard_to_logit_hazard(vector lhaz, int n) {
  * @return A vector of discretised logit hazards or log probabilities.
  * 
  * @note This function integrates several steps:
- *       1. Generates LCDF values using `lcdf_vectorised`.
+ *       1. Generates LCDF values using `lcdf_discretised`.
  *       2. Normalises these LCDF values with
  *          `normalise_lcdf_as_uniform_double_censored`.
  *       3. Converts LCDF to log probabilities using
@@ -261,7 +261,7 @@ vector log_hazard_to_logit_hazard(vector lhaz, int n) {
  *          and `log_hazard_to_logit_hazard`.
  * 
  * Dependencies:
- *   - `lcdf_vectorised`
+ *   - `lcdf_discretised`
  *   - `normalise_lcdf_as_uniform_double_censored`
  *   - `lcdf_to_uniform_double_censored_log_prob`
  *   - `lprob_to_uniform_double_censored_log_hazard`
@@ -272,7 +272,7 @@ vector discretised_logit_hazard(real mu, real sigma, int n, int dist,
   vector[n] lcdf;
   vector[n] lprob;
   vector[n] logit_haz; 
-  lcdf = lcdf_vectorised(mu, sigma, n, dist);
+  lcdf = lcdf_discretised(mu, sigma, n, dist);
   lcdf = normalise_lcdf_as_uniform_double_censored(lcdf, n, max_strat);
   lprob = lcdf_to_uniform_double_censored_log_prob(lcdf, n);
   if (ref_as_p == 1) {

--- a/inst/stan/functions/discretised_logit_hazard.stan
+++ b/inst/stan/functions/discretised_logit_hazard.stan
@@ -283,22 +283,22 @@ vector log_hazard_to_logit_hazard(vector lhaz) {
  *   - `lprob_to_uniform_double_censored_log_hazard`
  *   - `log_hazard_to_logit_hazard`
  */
-vector discretised_logit_hazard(real mu, real sigma, int n, int dist, 
+vector discretised_logit_hazard(real mu, real sigma, int dmax, int dist, 
                                 int max_strat, int ref_as_p) {
-  vector[n] lcdf;
-  vector[n] lprob;
-  vector[n] logit_haz; 
-  lcdf = lcdf_discretised(mu, sigma, n, dist);
-  lcdf = normalise_lcdf_as_uniform_double_censored(lcdf, n, max_strat);
-  lprob = lcdf_to_uniform_double_censored_log_prob(lcdf, n);
+  vector[dmax] lcdf;
+  vector[dmax] lprob;
+  vector[dmax] logit_haz; 
+  lcdf = lcdf_discretised(mu, sigma, dmax, dist);
+  lcdf = normalise_lcdf_as_uniform_double_censored(lcdf, dmax, max_strat);
+  lprob = lcdf_to_uniform_double_censored_log_prob(lcdf, dmax);
   if (ref_as_p == 1) {
     // In the mode where there are no hazard effects downstream functions
     // make use of the log probability directly so we return it here without
     // converting to the logit hazard.
     logit_haz = lprob;
   }else{
-    vector[n] lhaz;
-    lhaz = lprob_to_uniform_double_censored_log_hazard(lprob, lcdf, n);
+    vector[dmax] lhaz;
+    lhaz = lprob_to_uniform_double_censored_log_hazard(lprob, lcdf, dmax);
     logit_haz = log_hazard_to_logit_hazard(lhaz);
   }
   return(logit_haz);

--- a/inst/stan/functions/discretised_logit_hazard.stan
+++ b/inst/stan/functions/discretised_logit_hazard.stan
@@ -225,14 +225,13 @@ vector lprob_to_uniform_double_censored_log_hazard(vector lprob, vector lcdf,
  * distributions to logit hazards.
  * 
  * @param lhaz Vector of log hazards.
- *
- * @param n Number of hazards.
  * 
  * @return Vector of logit hazards.
  * 
  * @note Final transformation step in `discretised_logit_hazard`.
  */
-vector log_hazard_to_logit_hazard(vector lhaz, int n) {
+vector log_hazard_to_logit_hazard(vector lhaz) {
+  int n = num_elements(lhaz);
   vector[n] logit_haz;
   // Logit transformation
   logit_haz[1:(n-1)] = lhaz[1:(n-1)] - log1m_exp(lhaz[1:(n-1)]);
@@ -300,7 +299,7 @@ vector discretised_logit_hazard(real mu, real sigma, int n, int dist,
   }else{
     vector[n] lhaz;
     lhaz = lprob_to_uniform_double_censored_log_hazard(lprob, lcdf, n);
-    logit_haz = log_hazard_to_logit_hazard(lhaz, n);
+    logit_haz = log_hazard_to_logit_hazard(lhaz);
   }
   return(logit_haz);
 }


### PR DESCRIPTION
This PR should close #302 by further improving the doxygen comments for the stan code in `discretised_logit_hazard.stan`.
 
## Description

The current doc mostly used the number of values/elements `n` in the various vectors for hazards, log-probabilities and cdfs. This was easy because they all have the same length, but failed to point out the differences in indexing between probabilities and cdfs. It also did not make clear the connection to the maximum delay assumption and the truncation that we apply to the distributions.

I now changed the documentation and interface of the internal functions to use an upper bound `u` instead of the number of elements `n`. This does not change anything semantically, as `n=u` in all cases currently supported by epinowcast. However, I find this more inuitive, as it stresses the truncation of the delay distributions at the maximum possible delay, makes it more in line with discrete bounded distributions in stan (see e.g. https://mc-stan.org/docs/functions-reference/discrete-range-distribution.html), and also makes it more natural to explain the derivations for the interval censoring imo. Another plus is that if we might want to add a lower bound as well at some point.

I also made some changes to distinguish more clearly between math formulas and vector variables used in the stan code, as their indexing differs.

Finally, the function `discretised_logit_hazard` now uses `dmax` as an input, which matches the main epinowcast stan code, and makes intuitive sense if `dmax` is interpreted as the delay at which we truncate the parametric delay distribution. As before, the hazards will go from `0:(dmax-1)`, because the interval for `dmax-1` reaches all the way up to `dmax`.

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [x] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [x] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
