### PR TITLE
ISSUE 305: first attempt to put reference_date >= min(report_date) into separate…

### DIFF
--- a/R/data-converters.R
+++ b/R/data-converters.R
@@ -65,19 +65,33 @@ enw_add_cumulative <- function(obs, by = NULL, copy = TRUE) {
 #' # Make use of maximum reported to calculate empirical daily reporting
 #' dt <- enw_add_max_reported(dt)
 #' enw_add_incidence(dt)
+
+# --------------
+##  temporary placeholder
+enw_check_date_sequence  <- function(obs, by=NULL, copy=TRUE) {
+
+  obs <- obs[, .SD[reference_date >= min(report_date) | is.na(reference_date)],
+    by = by
+  ]
+}
+# --------------
+
 enw_add_incidence <- function(obs, set_negatives_to_zero = TRUE, by = NULL,
                               copy = TRUE) {
   reports <- coerce_dt(
     obs, dates = TRUE, required_cols = c(by, "confirm"), copy = copy
   )
   data.table::setkeyv(reports, c(by, "reference_date", "report_date"))
+
   reports[, new_confirm := c(confirm[1], diff(confirm)),
     by = c("reference_date", by)
   ]
-  reports <- reports[,
-    .SD[reference_date >= min(report_date) | is.na(reference_date)],
-    by = by
-  ]
+
+# --------------
+  ## temporary
+  reports  <- enw_check_date_sequence(reports)
+# --------------
+
   reports <- reports[, delay := 0:(.N - 1), by = c("reference_date", by)]
 
   if (!is.null(reports$max_confirm)) {


### PR DESCRIPTION
Issue #305 
Not a a real PR.
**enw_add_incidence()**

I posted a question about **reference_date** on the **epinowcast forum**.

Appreciate any feedback or reading suggestions.


Here I removed the line code you questioned and replaced it with a bare-boned function.

`DT[ reference_date >= min(report_date) |  is.na(reference_date]`

Doubt this is what's needed, but want to understand better the reference vs report dates.
Thanks.

jim

 
## Description

This PR closes #<issue-number>.

[Describe the changes that you made in this pull request.]

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [ ] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
