### PR TITLE
Issue 436: Switch to epinowcast/actions/install-cmdstan

### DIFF
--- a/.github/actions/touchstone-recieve/action.yaml
+++ b/.github/actions/touchstone-recieve/action.yaml
@@ -100,10 +100,10 @@ runs:
           any::glue
           github::lorenzwalthert/touchstone${{ inputs.touchstone_ref}}
     - name: Install cmdstan
-      run: |
-        print(list.files("C:/rtools42"))
-        cmdstanr::check_cmdstan_toolchain(fix = TRUE)
-        cmdstanr::install_cmdstan(cores = 2, quiet = TRUE)
+      uses: epinowcast/actions/install-cmdstan@v1
+      with:
+        cmdstan-version: 'latest'
+        num-cores: 2
       shell: Rscript {0}
     - name: Remove global installation
       run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -76,11 +76,10 @@ jobs:
           needs: check
 
       - name: Install cmdstan
-        run: |
-          print(list.files("C:/rtools43"))
-          cmdstanr::check_cmdstan_toolchain(fix = TRUE)
-          cmdstanr::install_cmdstan(cores = 2, quiet = TRUE)
-        shell: Rscript {0}
+        uses: epinowcast/actions/install-cmdstan@v1
+        with:
+          cmdstan-version: 'latest'
+        num-cores: 2
 
       - uses: r-lib/actions/check-r-package@v2
         if:  matrix.config.r != '3.6'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -79,7 +79,7 @@ jobs:
         uses: epinowcast/actions/install-cmdstan@v1
         with:
           cmdstan-version: 'latest'
-        num-cores: 2
+          num-cores: 2
 
       - uses: r-lib/actions/check-r-package@v2
         if:  matrix.config.r != '3.6'

--- a/.github/workflows/check-cmdstan.yaml
+++ b/.github/workflows/check-cmdstan.yaml
@@ -55,7 +55,7 @@ jobs:
         uses: epinowcast/actions/install-cmdstan@v1
         with:
           cmdstan-version: 'latest'
-        num-cores: 2
+          num-cores: 2
 
       - name: Compile model and check syntax
         run: |

--- a/.github/workflows/check-cmdstan.yaml
+++ b/.github/workflows/check-cmdstan.yaml
@@ -52,10 +52,10 @@ jobs:
           extra-packages: local::.
 
       - name: Install cmdstan
-        run: |
-          cmdstanr::check_cmdstan_toolchain(fix = TRUE)
-          cmdstanr::install_cmdstan(cores = 2, quiet = TRUE)
-        shell: Rscript {0}
+        uses: epinowcast/actions/install-cmdstan@v1
+        with:
+          cmdstan-version: 'latest'
+        num-cores: 2
 
       - name: Compile model and check syntax
         run: |

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -31,10 +31,10 @@ jobs:
           needs: website
 
       - name: Install cmdstan
-        run: |
-          cmdstanr::check_cmdstan_toolchain(fix = TRUE)
-          cmdstanr::install_cmdstan(cores = 2, quiet = TRUE)
-        shell: Rscript {0}
+        uses: epinowcast/actions/install-cmdstan@v1
+        with:
+          cmdstan-version: 'latest'
+        num-cores: 2
 
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: epinowcast/actions/install-cmdstan@v1
         with:
           cmdstan-version: 'latest'
-        num-cores: 2
+          num-cores: 2
 
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -31,11 +31,10 @@ jobs:
           needs: coverage
 
       - name: Install cmdstan
-        run: |
-          print(list.files("C:/rtools42"))
-          cmdstanr::check_cmdstan_toolchain(fix = TRUE)
-          cmdstanr::install_cmdstan(cores = 2, quiet = TRUE)
-        shell: Rscript {0}
+        uses: epinowcast/actions/install-cmdstan@v1
+        with:
+          cmdstan-version: 'latest'
+        num-cores: 2
 
       - name: Test coverage
         run: covr::codecov(quiet = FALSE)

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: epinowcast/actions/install-cmdstan@v1
         with:
           cmdstan-version: 'latest'
-        num-cores: 2
+          num-cores: 2
 
       - name: Test coverage
         run: covr::codecov(quiet = FALSE)


### PR DESCRIPTION
This PR switches all actions to use the new `epinowcast/actions/install-cmdstan` action which comes with the addition of caching (and hence should slightly speed up CI). 

Note that there is an upstream issues with `cmdstanr` on windows platforms that is causing all windows CI to fail.

@sbfnk tagged due to similar work in `EpiNow2` but also might be of interest to @Bisaloo.