### PR TITLE
Issue-409: Improve documentation of the `priors` argument

### DIFF
--- a/R/epinowcast.R
+++ b/R/epinowcast.R
@@ -35,7 +35,8 @@
 #' [enw_model()].
 #'
 #' @param priors A `data.frame` with the following variables:
-#' `variable`, `mean`, `sd` describing normal priors. Priors in the
+#' `variable` (See details for expected values), `mean`, `sd` describing normal
+#' priors. Priors in the
 #' appropriate format are returned by [enw_reference()] as well as by
 #' other similar model specification functions. Priors in this data.frame
 #' replace the default priors specified by each model component.
@@ -46,6 +47,26 @@
 #' @return A object of the class "epinowcast" which inherits from
 #' [enw_preprocess_data()] and `data.table`, and combines the input data,
 #' priors, and output from the sampler specified in `enw_fit_opts()`.
+#' @details
+#' ## Priors
+#'
+#' The `priors` data.frame should have the following columns: `variable`,
+#' `mean`, and `sd`. The `variable` column expects the following values:
+#'  - refp_mean_int: Log mean intercept for parametric reference date delay
+#'  - refp_sd_int: Log standard deviation for the parametric reference date
+#'  delay
+#'  - refp_mean_beta_sd: Standard deviation of scaled pooled parametric
+#'  mean effects
+#'  - refp_sd_beta_sd: Standard deviation of scaled pooled parametric sd
+#'  effects
+#'  - refnp_int: Intercept for non-parametric reference date delay
+#'  - refnp_beta_sd: Standard deviation of scaled pooled non-parametric
+#'  effects
+#'
+#'  To specify a custom prior on the log mean intercept for the parametric
+#'  reference date delay for example, you would specify a row in the `priors`
+#'  data.frame as `priors = data.frame(variable = "refp_mean_int", mean = 1,
+#'  sd = 0.1)`. This will replace the default prior for the log mean intercept.
 #' @inheritParams enw_obs
 #' @importFrom purrr map transpose flatten walk
 #' @importFrom cli cli_warn

--- a/man/epinowcast.Rd
+++ b/man/epinowcast.Rd
@@ -51,7 +51,8 @@ further details.}
 \code{\link[=enw_model]{enw_model()}}.}
 
 \item{priors}{A \code{data.frame} with the following variables:
-\code{variable}, \code{mean}, \code{sd} describing normal priors. Priors in the
+\code{variable} (See details for expected values), \code{mean}, \code{sd} describing normal
+priors. Priors in the
 appropriate format are returned by \code{\link[=enw_reference]{enw_reference()}} as well as by
 other similar model specification functions. Priors in this data.frame
 replace the default priors specified by each model component.}
@@ -71,6 +72,29 @@ defined models. By default a model that assumes a fixed parametric reporting
 distribution with a flexible expectation model is used. Explore the
 individual model components for additional documentation and see the package
 case studies for example model specifications for different tasks.
+}
+\details{
+\subsection{Priors}{
+
+The \code{priors} data.frame should have the following columns: \code{variable},
+\code{mean}, and \code{sd}. The \code{variable} column expects the following values:
+\itemize{
+\item refp_mean_int: Log mean intercept for parametric reference date delay
+\item refp_sd_int: Log standard deviation for the parametric reference date
+delay
+\item refp_mean_beta_sd: Standard deviation of scaled pooled parametric
+mean effects
+\item refp_sd_beta_sd: Standard deviation of scaled pooled parametric sd
+effects
+\item refnp_int: Intercept for non-parametric reference date delay
+\item refnp_beta_sd: Standard deviation of scaled pooled non-parametric
+effects
+}
+
+To specify a custom prior on the log mean intercept for the parametric
+reference date delay for example, you would specify a row in the \code{priors}
+data.frame as \code{priors = data.frame(variable = "refp_mean_int", mean = 1, sd = 0.1)}. This will replace the default prior for the log mean intercept.
+}
 }
 \examples{
 \dontshow{if (interactive()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #409.

This PR seeks to improve the documentation on how to specify the `priors` argument of the `epinowcast()` function. It expands on how to specify the `variable` column of the prior argument. 

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [x] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [x] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] My code follows the established coding standards.
- [x] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
