### PR TITLE
Issue #481: Add support for probability aggregation to `expected_obs()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 @medewitt, and @seabbs reviewed pull requests for this release.
 
-@pearsonca, @athowes, @medewitt, and @seabbs reported bugs, made suggestions, or contributed to discussions that led to improvements in this release.
+@pearsonca, @athowes, @medewitt, @jessalynnsebastian, and @seabbs reported bugs, made suggestions, or contributed to discussions that led to improvements in this release.
 
 ## Breaking changes
 
@@ -17,6 +17,7 @@
 ## Package
 
 - Experimental support for `CmdStanModel$pathfinder` has been added to the package via `enw_pathfinder()`. This fitting method approximates the posterior distribution using a variational inference method. It may be useful for rapid prototyping, informing initialisation of HMC runs, and settings where compute time is limited. Likely downsides are poorly calibrated estimates and instability for more complex model formulations. See #464 by @seabbs and reviewed by @medewitt.
+- Support for probability aggregation has been added to `expected_obs()`. See #482 by @jessalynnsebastian and reviewed by @seabbs.
 
 ## Documentation
 

--- a/inst/stan/functions/expected_obs.stan
+++ b/inst/stan/functions/expected_obs.stan
@@ -77,6 +77,17 @@
  * # 0.273 0.023 0.112 0.082 0.065 0.221 0.025 0.021 0.019 0.016 0.014 0.058
  * # 0.007 0.007 0.006 0.024 0.003 0.003 0.003 0.000 0.003 0.002 0.002 0.002
  * # 0.002 0.002 0.002 0.002 0.002 0.002
+ *
+ * Example with aggregation of probabilities where aggregation occurs on every fifth day
+ * agg_probs <- matrix(c(rep(0, times = 30 * 4),
+ *                       rep(c(rep(1, times = 5),
+ *                             rep(0, times = 6 * 5 + 30 * 4)),
+ *                           times = 5),
+ *                       rep(1, times = 5)), ncol = 30, byrow = TRUE)
+ * eobs <- exp(expected_obs(tar_obs, date_p + rep(0, 30), 1, 1, agg_probs))
+ * # -Inf -Inf -Inf -Inf -0.4630154 -Inf -Inf -Inf -Inf -1.8219081
+ * # -Inf -Inf -Inf -Inf -2.4549990 -Inf -Inf -Inf -Inf -2.8994851
+ * # -Inf -Inf -Inf -Inf -3.2477183 -Inf -Inf -Inf -Inf -3.5362414
  */
 vector expected_obs(real tar_obs, vector lh, int ref_as_p, int agg_probs, matrix agg_indicator) {
   int t = num_elements(lh);

--- a/inst/stan/functions/expected_obs.stan
+++ b/inst/stan/functions/expected_obs.stan
@@ -17,7 +17,7 @@
  *
  * @param agg_probs An integer flag (0 or 1) indicating whether the reporting probabilities should be aggregated. Set to 1 when the probabilities should be aggregated, otherwise 0.
  *
- * @param agg_indicator An array of integer flags (0 or 1) representing the aggregation of reporting probabilities.
+ * @param agg_indicator A matrix of integer flags (0 or 1) representing the aggregation of reporting probabilities.
  * 
  * @return A vector representing the expected observations for each date by
  * date of report. The length of the vector matches the length of `lh`.
@@ -75,7 +75,7 @@
  * # 0.007 0.007 0.006 0.024 0.003 0.003 0.003 0.000 0.003 0.002 0.002 0.002
  * # 0.002 0.002 0.002 0.002 0.002 0.002
  */
-vector expected_obs(real tar_obs, vector lh, int ref_as_p, int agg_probs, int agg_indicator[,]) {
+vector expected_obs(real tar_obs, vector lh, int ref_as_p, int agg_probs, matrix agg_indicator) {
   int t = num_elements(lh);
   vector[t] exp_obs;
   vector[t] p;
@@ -90,7 +90,7 @@ vector expected_obs(real tar_obs, vector lh, int ref_as_p, int agg_probs, int ag
     }
   }
   if (agg_probs == 1) {
-    p = p * agg_indicator;
+    p = agg_indicator * p;
   }
   profile("model_likelihood_expected_obs_prod_p") {
     exp_obs = tar_obs + p;

--- a/inst/stan/functions/expected_obs.stan
+++ b/inst/stan/functions/expected_obs.stan
@@ -93,7 +93,9 @@ vector expected_obs(real tar_obs, vector lh, int ref_as_p, int agg_probs, matrix
     }
   }
   if (agg_probs == 1) {
+    p = exp(p);
     p = agg_indicator * p;
+    p = log(p);
   }
   profile("model_likelihood_expected_obs_prod_p") {
     exp_obs = tar_obs + p;

--- a/inst/stan/functions/expected_obs.stan
+++ b/inst/stan/functions/expected_obs.stan
@@ -89,7 +89,7 @@ vector expected_obs(real tar_obs, vector lh, int ref_as_p, int agg_probs, int ag
     p = hazard_to_log_prob(p);
     }
   }
-  if (agg_probs == 1){
+  if (agg_probs == 1) {
     p = p * agg_indicator;
   }
   profile("model_likelihood_expected_obs_prod_p") {

--- a/inst/stan/functions/expected_obs.stan
+++ b/inst/stan/functions/expected_obs.stan
@@ -14,6 +14,10 @@
  * 
  * @param ref_as_p An integer flag (0 or 1) indicating whether the reference date input should be treated as a logit hazard or probability. Set to 1 when
  * no report date effects are present, otherwise 0.
+ *
+ * @param agg_probs An integer flag (0 or 1) indicating whether the reporting probabilities should be aggregated. Set to 1 when the probabilities should be aggregated, otherwise 0.
+ *
+ * @param agg_indicator An array of integer flags (0 or 1) representing the aggregation of reporting probabilities.
  * 
  * @return A vector representing the expected observations for each date by
  * date of report. The length of the vector matches the length of `lh`.
@@ -36,19 +40,19 @@
  * rep_lh <- rep(0, 30)
  *
  * Example with no reporting day effect
- * eobs <- exp(expected_obs(tar_obs, date_p + rep(0, 30), 1))
+ * eobs <- exp(expected_obs(tar_obs, date_p + rep(0, 30), 1, 0, [0]))
  * all.equal(eobs, date_p)
  *
  * Example with hazard effect only on last date of report
  * ref_lh <- logit(hazard_to_log_prob(date_p))
- * eobs <- exp(expected_obs(tar_obs, ref_lh, c(rep(0, 29), 0.1), 0))
+ * eobs <- exp(expected_obs(tar_obs, ref_lh, c(rep(0, 29), 0.1), 0, 0, [0]))
  * all.equal(eobs, date_p)
  *
  * Example with a single day of additional reporting hazard and
  * no differential probability due to the reference date.
  * rep_lh <- rep(0, 30); rep_lh[7] = 2
  * equal_lh <- logit(hazard_to_log_prob(rep(1/30, 30)))
- * round(exp(expected_obs(tar_obs, equal_lh + rep_lh, 0)), 3)
+ * round(exp(expected_obs(tar_obs, equal_lh + rep_lh, 0, 0, [0])), 3)
  * # 0.033 0.033 0.033 0.033 0.033 0.033 0.195 0.026 0.026 0.026 0.026 0.026
  * # 0.026 0.026 0.026 0.026 0.026 0.026 0.026 0.026 0.026 0.026 0.026 0.026
  * # 0.026 0.026 0.026 0.026 0.026 0.026
@@ -58,37 +62,38 @@
  * rep_lh <- rep(0, 30)
  * rep_lh[c(6, 12, 16)] = 2
  * rep_lh[c(2, 20)] = -2
- * round(exp(expected_obs(tar_obs, equal_lh + rep_lh, 0)), 3)
+ * round(exp(expected_obs(tar_obs, equal_lh + rep_lh, 0, 0, [0])), 3)
  * # 0.033 0.005 0.034 0.034 0.034 0.202 0.027 0.027 0.027 0.027 0.027 0.151
  * # 0.021 0.021 0.021 0.106 0.014 0.014 0.014 0.002 0.016 0.016 0.016 0.016
  * # 0.016 0.016 0.016 0.016 0.016 0.016
  *
  * Example combining both date of reference and date of report effects
- * eobs <- exp(expected_obs(tar_obs, ref_lh + rep_lh, 0))
+ * eobs <- exp(expected_obs(tar_obs, ref_lh + rep_lh, 0, 0, [0]))
  * round(sum(eobs - 1e-4), 5) == 1
  * round(eobs, 3)
  * # 0.273 0.023 0.112 0.082 0.065 0.221 0.025 0.021 0.019 0.016 0.014 0.058
  * # 0.007 0.007 0.006 0.024 0.003 0.003 0.003 0.000 0.003 0.002 0.002 0.002
  * # 0.002 0.002 0.002 0.002 0.002 0.002
  */
-vector expected_obs(real tar_obs, vector lh, int ref_as_p) {
+vector expected_obs(real tar_obs, vector lh, int ref_as_p, int agg_probs, int agg_indicator[,]) {
   int t = num_elements(lh);
   vector[t] exp_obs;
+  vector[t] p;
   if (ref_as_p == 1) {
-    profile("model_likelihood_expected_obs_prod_p") {
-    exp_obs = tar_obs + lh;
-    }
+    p = lh;
   }else{
-    vector[t] p;
     profile("model_likelihood_expected_obs_inv_logit") {
     p = inv_logit(lh);
     }
     profile("model_likelihood_expected_obs_hazard_to_prob") {
     p = hazard_to_log_prob(p);
     }
-    profile("model_likelihood_expected_obs_prod_p") {
+  }
+  if (agg_probs == 1){
+    p = p * agg_indicator;
+  }
+  profile("model_likelihood_expected_obs_prod_p") {
     exp_obs = tar_obs + p;
     }
-  }
   return(exp_obs);
 }

--- a/inst/stan/functions/expected_obs.stan
+++ b/inst/stan/functions/expected_obs.stan
@@ -12,7 +12,7 @@
  * a given day. When `ref_as_p` is 0, this should be the logit hazard instead
  * of probability.
  * 
- * @param ref_as_p An integer flag (0 or 1) indicating whether the reference dateinput should be treated as a logit hazard or probability. Set to 1 when
+ * @param ref_as_p An integer flag (0 or 1) indicating whether the reference date input should be treated as a logit hazard or probability. Set to 1 when
  * no report date effects are present, otherwise 0.
  *
  * @param agg_probs An integer flag (0 or 1) indicating whether the reporting probabilities should be aggregated. Set to 1 when the probabilities should be aggregated, otherwise 0.
@@ -88,6 +88,8 @@
  * # -Inf -Inf -Inf -Inf -0.4630154 -Inf -Inf -Inf -Inf -1.8219081
  * # -Inf -Inf -Inf -Inf -2.4549990 -Inf -Inf -Inf -Inf -2.8994851
  * # -Inf -Inf -Inf -Inf -3.2477183 -Inf -Inf -Inf -Inf -3.5362414
+ * # Can visualize what this does to the probabilities with
+ * eobs |> exp() |> plot()
  */
 vector expected_obs(real tar_obs, vector lh, int ref_as_p, int agg_probs, matrix agg_indicator) {
   int t = num_elements(lh);
@@ -104,9 +106,7 @@ vector expected_obs(real tar_obs, vector lh, int ref_as_p, int agg_probs, matrix
     }
   }
   if (agg_probs == 1) {
-    p = exp(p);
-    p = agg_indicator * p;
-    p = log(p);
+    p = log(agg_indicator * exp(p));
   }
   profile("model_likelihood_expected_obs_prod_p") {
     exp_obs = tar_obs + p;

--- a/inst/stan/functions/expected_obs.stan
+++ b/inst/stan/functions/expected_obs.stan
@@ -12,12 +12,15 @@
  * a given day. When `ref_as_p` is 0, this should be the logit hazard instead
  * of probability.
  * 
- * @param ref_as_p An integer flag (0 or 1) indicating whether the reference date input should be treated as a logit hazard or probability. Set to 1 when
+ * @param ref_as_p An integer flag (0 or 1) indicating whether the reference dateinput should be treated as a logit hazard or probability. Set to 1 when
  * no report date effects are present, otherwise 0.
  *
  * @param agg_probs An integer flag (0 or 1) indicating whether the reporting probabilities should be aggregated. Set to 1 when the probabilities should be aggregated, otherwise 0.
  *
- * @param agg_indicator A matrix of integer flags (0 or 1) representing the aggregation of reporting probabilities.
+ * @param agg_indicator A matrix of integer flags (0 or 1) representing the aggregation of reporting probabilities,
+ * designed to be left-multiplied to a column vector of reporting probabilities. 
+ * Presence of a 1 in a column indicates that that index in the probability column vector will be aggregated,
+ * and presence of a 1 in a row indicates that aggregated probability will be placed on that index in the new probability vector.
  * 
  * @return A vector representing the expected observations for each date by
  * date of report. The length of the vector matches the length of `lh`.

--- a/inst/stan/functions/expected_obs_from.stan
+++ b/inst/stan/functions/expected_obs_from.stan
@@ -64,7 +64,8 @@ vector expected_obs_from_index(int i, array[] vector imp_obs,
   // combine expected final obs and time effects to get expected obs
   profile("model_likelihood_expected_obs") {    
   int agg_probs = 0;
-  int agg_indicator = [0];
+  matrix[1, 1] agg_indicator;
+  agg_indicator[1, 1] = 0;
   log_exp_obs = expected_obs(tar_obs, lh, ref_as_p, agg_probs, agg_indicator);
   }
   return(log_exp_obs);

--- a/inst/stan/functions/expected_obs_from.stan
+++ b/inst/stan/functions/expected_obs_from.stan
@@ -62,8 +62,10 @@ vector expected_obs_from_index(int i, array[] vector imp_obs,
     );
   }
   // combine expected final obs and time effects to get expected obs
-  profile("model_likelihood_expected_obs") {
-  log_exp_obs = expected_obs(tar_obs, lh, ref_as_p);
+  profile("model_likelihood_expected_obs") {    
+  int agg_probs = 0;
+  int agg_indicator = [0];
+  log_exp_obs = expected_obs(tar_obs, lh, ref_as_p, agg_probs, agg_indicator);
   }
   return(log_exp_obs);
 }

--- a/tests/testthat/test-stan_expected_obs.R
+++ b/tests/testthat/test-stan_expected_obs.R
@@ -1,0 +1,25 @@
+skip_on_cran()
+skip_on_os("windows")
+skip_on_os("mac")
+skip_on_local()
+
+enw_stan_to_r(
+  c("expected_obs.stan", "hazard.stan"),
+  system.file("stan", "functions", package = "epinowcast")
+)
+# note these tests require enw_stan_to_r() to be run first
+
+test_that("expected_obs() aggregates probabilities correctly", {
+  tar_obs <- 0
+  lh <- c(0.1, 0.2, 0.3, 0.4)
+  ref_as_p <- 1
+  agg_probs <- 1
+  agg_indicator <- matrix(c(0, 0, 0, 0,
+                            1, 1, 0, 0,
+                            0, 0, 0, 0,
+                            0, 0, 1, 1), nrow = 4, byrow = TRUE)
+  exp_obs <- expected_obs(tar_obs, lh, ref_as_p, agg_probs, agg_indicator)
+  expect_equal(exp_obs, c(0.0, 0.3, 0.0, 0.7), tolerance = 1e-15)
+  # Note below is only true since ref_as_p is 1
+  expect_identical(sum(exp_obs), sum(lh))
+})

--- a/tests/testthat/test-stan_expected_obs.R
+++ b/tests/testthat/test-stan_expected_obs.R
@@ -10,16 +10,16 @@ enw_stan_to_r(
 # note these tests require enw_stan_to_r() to be run first
 
 test_that("expected_obs() aggregates probabilities correctly", {
-  tar_obs <- 0
-  lh <- c(0.1, 0.2, 0.3, 0.4)
-  ref_as_p <- 1
-  agg_probs <- 1
-  agg_indicator <- matrix(c(0, 0, 0, 0,
-                            1, 1, 0, 0,
-                            0, 0, 0, 0,
-                            0, 0, 1, 1), nrow = 4, byrow = TRUE)
-  exp_obs <- expected_obs(tar_obs, lh, ref_as_p, agg_probs, agg_indicator)
-  expect_equal(exp_obs, c(0.0, 0.3, 0.0, 0.7), tolerance = 1e-15)
-  # Note below is only true since ref_as_p is 1
-  expect_identical(sum(exp_obs), sum(lh))
+  tar_obs <- log(1)
+  lh <- log(
+    (plnorm(1:30, 1.5, 2) - plnorm(0:29, 1.5, 2)) / plnorm(30, 1.5, 2)
+    )
+  agg_probs <- matrix(c(rep(0, times = 30 * 4),
+                        rep(c(rep(1, times = 5),
+                              rep(0, times = 6 * 5 + 30 * 4)),
+                            times = 5),
+                        rep(1, times = 5)), ncol = 30, byrow = TRUE)
+  exp_obs <- expected_obs(tar_obs, lh, ref_as_p = 1, agg_probs = 1, agg_probs)
+  exp_output <- as.vector(tar_obs + log(agg_probs %*% exp(lh)))
+  expect_equal(object = exp_obs, expected = exp_output, tolerance = 1e-15)
 })


### PR DESCRIPTION
## Description

This PR closes #481. It adds an indicator (`agg_probs`) and a matrix argument (`agg_indicator`) to `expected_obs()` that indicate whether to aggregate and how the aggregation should be performed, respectively. The matrix argument is structured to be directly multiplied to the probability vector: the rows represent which index the aggregated probability should be placed on in the new probability vector that accounts for the reporting cycle, and the columns represent whether a given probability in the probability vector should be aggregated. For example, if we had the aggregation matrix 

```math
\texttt{agg}\_\texttt{indicator} = \begin{bmatrix} 0 & 0 & 0 & 0 & 0 & 0 \\\ 0 & 0 & 0 & 0 & 0 & 0 \\\ 1 & 1 & 1 & 0 & 0 & 0 \\\ 0 & 0 & 0 & 0 & 0 & 0 \\\ 0 & 0 & 0 & 0 & 0 & 0 \\\ 0 & 0 & 0 & 1 & 1 & 1 \end{bmatrix}
```
the first 3 elements of the probability vector would be summed and placed on the third element of the new probability vector, and the last three elements would be summed and placed on the sixth element.

For now, `agg_probs` is set to 0 (for no aggregation) and `agg_indicator` is set to [0] in `expected_obs_from_index()`, since the infrastructure to implement this method doesn't yet exist.


## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [x] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] My code follows the established coding standards.
- [x] I have added a news item linked to this PR.
- [x] I have reviewed CI checks for this PR and addressed them as far as I am able.
