### PR TITLE
Reparameterise delay standard deviation on the log scale

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 
 ## Breaking changes
 
-- The `refp_sd_int` parameter has been replaced with `refp_sd_int_log` to avoid transforming within the model. The `refp_sd_int` parameter can be recovered by taking the exponential of `refp_sd_int_log`. See # by @seabbs and @<REVIEWER>.
+- The `refp_sd_int` parameter has been replaced with `refp_sd_int_log` to avoid transforming within the model. The `refp_sd_int` parameter can be recovered by taking the exponential of `refp_sd_int_log`. See #515 by @seabbs and @<REVIEWER>.
 
 ## Bugs
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 ## Breaking changes
 
+- The `refp_sd_int` parameter has been replaced with `refp_sd_int_log` to avoid transforming within the model. The `refp_sd_int` parameter can be recovered by taking the exponential of `refp_sd_int_log`. See # by @seabbs and @<REVIEWER>.
+
 ## Bugs
 
 - Fixed a bug where `enw_nowcast_summary()` and `enw_nowcast_samples()` incorrectly selected reference dates to include in their outputs when time steps were not days. See #473 by @jessalynnsebastian and reviewed by @seabbs.

--- a/inst/stan/chunks/debug.stan
+++ b/inst/stan/chunks/debug.stan
@@ -17,7 +17,7 @@
         print("Logmean and Logsd intercept");
         print(refp_mean_int);
         if (model_refp > 1) {
-          print(refp_sd_int);
+          print(exp(refp_sd_int_log));
         }
         print("Logmean and Logsd for pmf");
         print(refp_mean[i]);

--- a/tests/testthat/_snaps/enw_reference.md
+++ b/tests/testthat/_snaps/enw_reference.md
@@ -1082,25 +1082,25 @@
       $priors
                   variable
       1:     refp_mean_int
-      2:       refp_sd_int
+      2:   refp_sd_int_log
       3: refp_mean_beta_sd
       4:   refp_sd_beta_sd
       5:         refnp_int
       6:     refnp_beta_sd
-                                                            description
-      1:         Log mean intercept for parametric reference date delay
-      2: Log standard deviation for the parametric reference date delay
-      3:    Standard deviation of scaled pooled parametric mean effects
-      4:      Standard deviation of scaled pooled parametric sd effects
-      5:              Intercept for non-parametric reference date delay
-      6:     Standard deviation of scaled pooled non-parametric effects
-                  distribution mean sd
-      1:                Normal  1.0  1
-      2: Zero truncated normal  0.5  1
-      3: Zero truncated normal  0.0  1
-      4: Zero truncated normal  0.0  1
-      5:                Normal  0.0  1
-      6: Zero truncated normal  0.0  1
+                                                                                  description
+      1:                               Log mean intercept for parametric reference date delay
+      2: The log of the log standard deviation for the parametric reference date\n      delay
+      3:                          Standard deviation of scaled pooled parametric mean effects
+      4:                            Standard deviation of scaled pooled parametric sd effects
+      5:                                    Intercept for non-parametric reference date delay
+      6:                           Standard deviation of scaled pooled non-parametric effects
+                  distribution mean  sd
+      1:                Normal  1.0 1.0
+      2:                Normal -0.7 0.5
+      3: Zero truncated normal  0.0 1.0
+      4: Zero truncated normal  0.0 1.0
+      5:                Normal  0.0 1.0
+      6: Zero truncated normal  0.0 1.0
       
 
 # enw_reference supports non-parametric models
@@ -1210,25 +1210,25 @@
       $priors
                   variable
       1:     refp_mean_int
-      2:       refp_sd_int
+      2:   refp_sd_int_log
       3: refp_mean_beta_sd
       4:   refp_sd_beta_sd
       5:         refnp_int
       6:     refnp_beta_sd
-                                                            description
-      1:         Log mean intercept for parametric reference date delay
-      2: Log standard deviation for the parametric reference date delay
-      3:    Standard deviation of scaled pooled parametric mean effects
-      4:      Standard deviation of scaled pooled parametric sd effects
-      5:              Intercept for non-parametric reference date delay
-      6:     Standard deviation of scaled pooled non-parametric effects
-                  distribution mean sd
-      1:                Normal  1.0  1
-      2: Zero truncated normal  0.5  1
-      3: Zero truncated normal  0.0  1
-      4: Zero truncated normal  0.0  1
-      5:                Normal  0.0  1
-      6: Zero truncated normal  0.0  1
+                                                                                  description
+      1:                               Log mean intercept for parametric reference date delay
+      2: The log of the log standard deviation for the parametric reference date\n      delay
+      3:                          Standard deviation of scaled pooled parametric mean effects
+      4:                            Standard deviation of scaled pooled parametric sd effects
+      5:                                    Intercept for non-parametric reference date delay
+      6:                           Standard deviation of scaled pooled non-parametric effects
+                  distribution mean  sd
+      1:                Normal  1.0 1.0
+      2:                Normal -0.7 0.5
+      3: Zero truncated normal  0.0 1.0
+      4: Zero truncated normal  0.0 1.0
+      5:                Normal  0.0 1.0
+      6: Zero truncated normal  0.0 1.0
       
 
 # Parametric and non-parametric models can be jointly specified
@@ -1337,24 +1337,24 @@
       $priors
                   variable
       1:     refp_mean_int
-      2:       refp_sd_int
+      2:   refp_sd_int_log
       3: refp_mean_beta_sd
       4:   refp_sd_beta_sd
       5:         refnp_int
       6:     refnp_beta_sd
-                                                            description
-      1:         Log mean intercept for parametric reference date delay
-      2: Log standard deviation for the parametric reference date delay
-      3:    Standard deviation of scaled pooled parametric mean effects
-      4:      Standard deviation of scaled pooled parametric sd effects
-      5:              Intercept for non-parametric reference date delay
-      6:     Standard deviation of scaled pooled non-parametric effects
-                  distribution mean sd
-      1:                Normal  1.0  1
-      2: Zero truncated normal  0.5  1
-      3: Zero truncated normal  0.0  1
-      4: Zero truncated normal  0.0  1
-      5:                Normal  0.0  1
-      6: Zero truncated normal  0.0  1
+                                                                                  description
+      1:                               Log mean intercept for parametric reference date delay
+      2: The log of the log standard deviation for the parametric reference date\n      delay
+      3:                          Standard deviation of scaled pooled parametric mean effects
+      4:                            Standard deviation of scaled pooled parametric sd effects
+      5:                                    Intercept for non-parametric reference date delay
+      6:                           Standard deviation of scaled pooled non-parametric effects
+                  distribution mean  sd
+      1:                Normal  1.0 1.0
+      2:                Normal -0.7 0.5
+      3: Zero truncated normal  0.0 1.0
+      4: Zero truncated normal  0.0 1.0
+      5:                Normal  0.0 1.0
+      6: Zero truncated normal  0.0 1.0
       
 

--- a/tests/testthat/test-enw_reference.R
+++ b/tests/testthat/test-enw_reference.R
@@ -54,16 +54,11 @@ test_that("enw_reference supports parametric models", {
   expect_named(
     inits,
     c(
-      "refp_mean_int", "refp_sd_int", "refp_mean_beta",
+      "refp_mean_int", "refp_sd_int_log", "refp_mean_beta",
       "refp_sd_beta", "refp_mean_beta_sd", "refp_sd_beta_sd",
       "refnp_int", "refnp_beta", "refnp_beta_sd",
       "refp_mean", "refp_sd"
     )
-  )
-  c(
-    "refp_mean_int", "ref_p_sd_int", "refp_mean_beta",
-    "refp_sd_beta", "refp_mean_beta_sd", "refp_sd_beta_sd",
-    "refp_mean", "refp_sd"
   )
   zero_length <- c("refnp_int", "refnp_beta", "refnp_beta_sd")
   expect_zero_length_or_not(zero_length, inits)
@@ -110,7 +105,7 @@ test_that("enw_reference supports non-parametric models", {
   )
   inits <- ref$inits(ref$data, ref$priors)()
   zero_length <- c(
-    "refp_mean_int", "refp_sd_int", "refp_mean_beta",
+    "refp_mean_int", "refp_sd_int_log", "refp_mean_beta",
     "refp_sd_beta", "refp_mean_beta_sd", "refp_sd_beta_sd",
     "refp_mean", "refp_sd"
   )


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

As the title this PR reparameterises the standard deviation intercept prior directly on the log scale. This avoids the current hard-coded log transforms. This is a potentially breaking change and has been flagged as such but I would expect this to in reality impact relatively few users.

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [ ] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
